### PR TITLE
AI Suggestions on-demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ experiments/llm-evaluation/venv
 python/services/logs/
 python/services/lo_mapping_service/app/services/batch_inputs/**
 **.env
+python/services/lo_mapping_service/env
+python/services/syllabi_service/env

--- a/docs/FastAPILOMappingService.md
+++ b/docs/FastAPILOMappingService.md
@@ -174,7 +174,7 @@ This service depends on several external systems:
 ### Key Environment Variables
 
 - `ALLOWED_ORIGINS`
-- `LO_MAPPING_REQUESTS_TABLE`
+- `LO_MAPPING_DYNAMODB_REQUESTS_TABLE`
 - `AWS_REGION`
 - `ACCESS_KEY`
 - `SECRET_KEY`

--- a/laravel/app/Http/Controllers/CourseProgramController.php
+++ b/laravel/app/Http/Controllers/CourseProgramController.php
@@ -375,6 +375,12 @@ class CourseProgramController extends Controller
             ->pluck('map_scale_id', 'abbreviation')
             ->toArray();
 
+        // Look up the "Not Applicable" scale (used to record AI's "is_mapped: false"
+        // suggestions on the N/A column). May not exist in every deployment, so guard.
+        $notApplicableScaleId = \App\Models\MappingScale::where('map_scale_id', 0)
+            ->orWhere('abbreviation', 'N/A')
+            ->value('map_scale_id');
+
         DB::beginTransaction();
         try {
             $rowsWritten = 0;
@@ -390,9 +396,15 @@ class CourseProgramController extends Controller
                     continue;
                 }
 
-                // Unmapped pair: write nothing. Absence of a row = "no AI suggestion."
-                // Avoids the map_scale_id=0 FK violation against mapping_scales.
                 if (!$isMapped || empty($mapLabels)) {
+                    if ($notApplicableScaleId !== null) {
+                        OutcomeMapAiSuggestion::updateOrCreate([
+                            'l_outcome_id'  => $cloId,
+                            'pl_outcome_id' => $ploId,
+                            'map_scale_id'  => $notApplicableScaleId,
+                        ]);
+                        $rowsWritten++;
+                    }
                     continue;
                 }
 

--- a/laravel/app/Http/Controllers/CourseProgramController.php
+++ b/laravel/app/Http/Controllers/CourseProgramController.php
@@ -16,6 +16,8 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class CourseProgramController extends Controller
 {
@@ -183,5 +185,86 @@ class CourseProgramController extends Controller
         // Mark mapping as hidden
         $courseProgram->ai_suggestion_status = !$courseProgram->ai_suggestion_status;
         $courseProgram->save();
+    }
+
+    public function generateAiSuggestions(Request $request, $courseId, $programId)
+    {
+        $USE_MOCK_DATA = true;
+
+        if ($USE_MOCK_DATA) {
+            Log::info("Generating AI suggestions (MOCK MODE) for course_id=$courseId, program_id=$programId");
+
+            return response()->json([
+                'status' => 'mock',
+                'message' => 'Mock AI suggestions generated successfully',
+                'request_id' => 'mock_request_' . uniqid(),
+                'course_id' => $courseId,
+                'program_id' => $programId,
+            ]);
+        }
+
+        try {
+            $course = Course::findOrFail($courseId);
+            $program = Program::findOrFail($programId);
+
+            $clos = $course->learningOutcomes()->get();
+            $plos = $program->programLearningOutcomes()->get();
+            $scales = $program->mappingScaleLevels()->get();
+
+            $payload = [
+                'course_id' => $courseId,
+                'program_id' => $programId,
+                'course_learning_outcomes' => $clos->map(function ($clo) {
+                    return [
+                        'l_outcome_id' => $clo->l_outcome_id,
+                        'l_outcome' => $clo->l_outcome,
+                    ];
+                })->toArray(),
+                'program_learning_outcomes' => $plos->map(function ($plo) {
+                    return [
+                        'pl_outcome_id' => $plo->pl_outcome_id,
+                        'pl_outcome' => $plo->pl_outcome,
+                    ];
+                })->toArray(),
+                'mapping_scales' => $scales->map(function ($scale) {
+                    return [
+                        'map_scale_id' => $scale->map_scale_id,
+                        'title' => $scale->title,
+                        'abbreviation' => $scale->abbreviation,
+                        'description' => $scale->description,
+                    ];
+                })->toArray(),
+            ];
+
+            $loMappingServiceUrl = config('services.lo_mapping.base_url');
+            Log::info("Calling lo_mapping_service at: $loMappingServiceUrl/map-program-outcomes");
+
+            $response = Http::post($loMappingServiceUrl . '/map-program-outcomes', $payload);
+
+            if ($response->failed()) {
+                Log::error('lo_mapping_service returned an error: ' . $response->body());
+                return response()->json([
+                    'status' => 'error',
+                    'message' => 'Failed to generate AI suggestions',
+                ], 500);
+            }
+
+            $data = $response->json();
+            Log::info('AI suggestion request submitted successfully: ' . json_encode($data));
+
+            return response()->json([
+                'status' => 'success',
+                'request_id' => $data['startedForRecordId'] ?? null,
+                'job_name' => $data['jobName'] ?? null,
+                'message' => $data['message'] ?? 'Request submitted',
+            ]);
+
+        } catch (\Exception $e) {
+            Log::error('Error generating AI suggestions: ' . $e->getMessage());
+            return response()->json([
+                'status' => 'error',
+                'message' => 'An error occurred while processing the request',
+            ], 500);
+        }
     }
 }

--- a/laravel/app/Http/Controllers/CourseProgramController.php
+++ b/laravel/app/Http/Controllers/CourseProgramController.php
@@ -189,7 +189,7 @@ class CourseProgramController extends Controller
 
     public function generateAiSuggestions(Request $request, $courseId, $programId)
     {
-        $USE_MOCK_DATA = true;
+        $USE_MOCK_DATA = false;
 
         if ($USE_MOCK_DATA) {
             Log::info("Generating AI suggestions (MOCK MODE) for course_id=$courseId, program_id=$programId");

--- a/laravel/app/Http/Controllers/CourseProgramController.php
+++ b/laravel/app/Http/Controllers/CourseProgramController.php
@@ -9,6 +9,7 @@ use App\Models\CourseProgram;
 use App\Models\CourseUser;
 use App\Models\Department;
 use App\Models\Faculty;
+use App\Models\OutcomeMapAiSuggestion;
 use App\Models\Program;
 use App\Models\Role;
 use App\Models\User;
@@ -16,6 +17,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -264,6 +266,173 @@ class CourseProgramController extends Controller
             return response()->json([
                 'status' => 'error',
                 'message' => 'An error occurred while processing the request',
+            ], 500);
+        }
+    }
+
+    /**
+     * Query the lo_mapping_service for in-flight status of multiple (course, program) pairs.
+     * Returns ['<programId>' => bool, ...] for the given course/program pairs.
+     * Used at Step 5 render time and for pre-click race checks.
+     */
+    public static function getInFlightStatuses(int $courseId, array $programIds): array
+    {
+        $pairs = array_map(fn($pid) => ['course_id' => $courseId, 'program_id' => (int) $pid], $programIds);
+
+        try {
+            $loMappingServiceUrl = config('services.lo_mapping.base_url');
+            $response = Http::timeout(10)->post(
+                $loMappingServiceUrl . '/in-flight-status',
+                ['pairs' => $pairs]
+            );
+
+            if ($response->failed()) {
+                Log::warning('getInFlightStatuses: lo_mapping_service returned an error: ' . $response->body());
+                return array_fill_keys($programIds, false);
+            }
+
+            $statuses = $response->json('statuses') ?? [];
+            $result = array_fill_keys($programIds, false);
+            foreach ($statuses as $entry) {
+                $pid = (int) ($entry['program_id'] ?? 0);
+                $result[$pid] = (bool) ($entry['in_flight'] ?? false);
+            }
+            return $result;
+        } catch (\Exception $e) {
+            Log::warning('getInFlightStatuses exception: ' . $e->getMessage());
+            return array_fill_keys($programIds, false);
+        }
+    }
+
+    public function checkInFlight(Request $request, $courseId, $programId)
+    {
+        $statuses = self::getInFlightStatuses((int) $courseId, [(int) $programId]);
+        return response()->json([
+            'in_flight' => $statuses[(int) $programId] ?? false,
+        ]);
+    }
+
+    public function checkAiResults(Request $request, $courseId, $programId)
+    {
+        // 1. Local DB is the source of truth for "is this complete?". Once
+        // storeAiSuggestions has run, ai_suggestion_status is true and we are done.
+        $courseProgram = CourseProgram::where(['course_id' => $courseId, 'program_id' => $programId])->first();
+        if ($courseProgram && $courseProgram->ai_suggestion_status) {
+            return response()->json(['status' => 'complete']);
+        }
+
+        // 2. Not yet complete. Ask FastAPI to poll for and trigger processing of any
+        // ready record. /process-pending-results returns immediately (background
+        // task), so this does not deadlock when artisan serve is single-threaded.
+        try {
+            $loMappingServiceUrl = config('services.lo_mapping.base_url');
+            $payload = [
+                'course_id'  => (string) $courseId,
+                'program_id' => (string) $programId,
+            ];
+
+            $statusRes = Http::timeout(10)->post(
+                $loMappingServiceUrl . '/poll-results-status',
+                $payload
+            );
+
+            if ($statusRes->ok() && ($statusRes->json('status') ?? null) === 'ready_to_process') {
+                Http::timeout(5)->post(
+                    $loMappingServiceUrl . '/process-pending-results',
+                    $payload
+                );
+            }
+        } catch (\Exception $e) {
+            Log::warning('checkAiResults: trigger error (will retry next poll): ' . $e->getMessage());
+        }
+
+        return response()->json(['status' => 'pending']);
+    }
+
+    public function storeAiSuggestions(Request $request)
+    {
+        $courseId  = $request->input('course_id');
+        $programId = $request->input('program_id');
+        $status    = $request->input('status');
+        $results   = $request->input('results', []);
+
+        Log::info("Receiving AI suggestions: course_id=$courseId program_id=$programId status=$status results_count=" . count($results));
+
+        if ($status !== 'AWAITING_COMPLETION') {
+            Log::warning("AI suggestion job did not complete successfully (status=$status). Skipping suggestion storage.");
+            return response()->json([
+                'status'  => 'skipped',
+                'message' => "Job status was '$status', no suggestions to store.",
+            ]);
+        }
+
+        $program = Program::find($programId);
+        if (!$program) {
+            return response()->json(['status' => 'error', 'message' => "Program $programId not found"], 404);
+        }
+
+        $abbreviationToScaleId = $program->mappingScaleLevels
+            ->pluck('map_scale_id', 'abbreviation')
+            ->toArray();
+
+        DB::beginTransaction();
+        try {
+            $rowsWritten = 0;
+
+            foreach ($results as $result) {
+                $cloId     = isset($result['clo_id']) ? (int) $result['clo_id'] : null;
+                $ploId     = isset($result['plo_id']) ? (int) $result['plo_id'] : null;
+                $isMapped  = $result['is_mapped']  ?? false;
+                $mapLabels = $result['map_labels'] ?? [];
+
+                if ($cloId === null || $ploId === null) {
+                    Log::warning("Skipping result with missing clo_id or plo_id: " . json_encode($result));
+                    continue;
+                }
+
+                // Unmapped pair: write nothing. Absence of a row = "no AI suggestion."
+                // Avoids the map_scale_id=0 FK violation against mapping_scales.
+                if (!$isMapped || empty($mapLabels)) {
+                    continue;
+                }
+
+                foreach ($mapLabels as $label) {
+                    if (!isset($abbreviationToScaleId[$label])) {
+                        Log::warning("Unknown mapping scale abbreviation '$label' for program $programId. Skipping.");
+                        continue;
+                    }
+                    OutcomeMapAiSuggestion::updateOrCreate([
+                        'l_outcome_id'  => $cloId,
+                        'pl_outcome_id' => $ploId,
+                        'map_scale_id'  => $abbreviationToScaleId[$label],
+                    ]);
+                    $rowsWritten++;
+                }
+            }
+
+            $courseProgram = CourseProgram::where(['course_id' => $courseId, 'program_id' => $programId])->first();
+            if ($courseProgram) {
+                $courseProgram->ai_suggestion_status = true;
+                $courseProgram->manual_map_status    = true;
+                $courseProgram->save();
+            } else {
+                Log::warning("CourseProgram pivot not found for course_id=$courseId program_id=$programId. ai_suggestion_status not updated.");
+            }
+
+            DB::commit();
+            Log::info("AI suggestions stored: $rowsWritten rows.");
+
+            return response()->json([
+                'status'       => 'ok',
+                'rows_written' => $rowsWritten,
+            ]);
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            Log::error('Error storing AI suggestions: ' . $e->getMessage());
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Failed to store AI suggestions',
             ], 500);
         }
     }

--- a/laravel/app/Http/Controllers/CourseWizardController.php
+++ b/laravel/app/Http/Controllers/CourseWizardController.php
@@ -431,11 +431,21 @@ class CourseWizardController extends Controller
             $description = "";
         }
 
+        // Query lo_mapping_service for in-flight AI suggestion requests so we can
+        // render each program in the correct state (Checking... vs AI Suggestion button)
+        // even when the request was triggered by a different user or session.
+        $programIds = $coursePrograms->pluck('program_id')->map(fn($id) => (int) $id)->all();
+        $aiSuggestionInFlight = \App\Http\Controllers\CourseProgramController::getInFlightStatuses(
+            (int) $course_id,
+            $programIds
+        );
+
         return view('courses.wizard.step5')->with('course', $course)->with('courseDescription', $description)->with('faculties', $faculties)->with('departments', $departments)->with('campuses', $campuses)
             ->with('user', $user)->with('oAct', $oAct)->with('oAss', $oAss)->with('outcomeMapsCount', $outcomeMapsCount)
             ->with('isEditor', $isEditor)->with('isViewer', $isViewer)->with('courseUsers', $courseUsers)->with('standardsOutcomeMapCount', $standardsOutcomeMapCount)
             ->with('outcomeMapsCountPerProgram', $outcomeMapsCountPerProgram)->with('outcomeMapsCountPerProgramCLO', $outcomeMapsCountPerProgramCLO)->with('standard_categories', $standard_categories)
-            ->with('expectedStandardOutcomeMapCount', $expectedStandardOutcomeMapCount)->with('expectedProgramOutcomeMapCount', $expectedProgramOutcomeMapCount)->with('hasNonAlignedCLO', $hasNonAlignedCLO)->with('l_outcomes', $l_outcomes);
+            ->with('expectedStandardOutcomeMapCount', $expectedStandardOutcomeMapCount)->with('expectedProgramOutcomeMapCount', $expectedProgramOutcomeMapCount)->with('hasNonAlignedCLO', $hasNonAlignedCLO)->with('l_outcomes', $l_outcomes)
+            ->with('aiSuggestionInFlight', $aiSuggestionInFlight);
     }
 
     public function step6($course_id, Request $request)

--- a/laravel/config/services.php
+++ b/laravel/config/services.php
@@ -35,4 +35,8 @@ return [
         'base_url' => env('PYTHON_API_URL'),
     ],
 
+    'lo_mapping' => [
+        'base_url' => env('LO_MAPPING_SERVICE_URL', 'http://127.0.0.1:8002'),
+    ],
+
 ];

--- a/laravel/package-lock.json
+++ b/laravel/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "curriculum-development-tool",
+    "name": "laravel",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/laravel/resources/views/courses/wizard/step5.blade.php
+++ b/laravel/resources/views/courses/wizard/step5.blade.php
@@ -95,13 +95,33 @@
 
                                                     <!-- AI Suggestion button -->
                                                     @if(!$courseProgram->pivot->ai_suggestion_status and $courseProgram->pivot->manual_map_status)
-                                                    <span id="buttonAISuggestion[{{$course->course_id}}][{{$courseProgram->program_id}}]"
-                                                          class="btn btn-sm btn-primary d-flex me-3 col-2 justify-content-center"
-                                                          role="button"
-                                                          data-toggle="modal" data-target="#AiSuggestionConfirmation{{$course->course_id}}{{$courseProgram->program_id}}">
+                                                        @php
+                                                            $_inFlight = isset($aiSuggestionInFlight) && !empty($aiSuggestionInFlight[$courseProgram->program_id]);
+                                                            $_aiBtnClass     = $_inFlight ? 'd-none' : 'd-flex';
+                                                            $_aiStatusClass  = $_inFlight ? 'd-flex' : 'd-none';
+                                                            $_pollAttrs      = $_inFlight ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
+                                                        @endphp
+                                                        <span id="buttonAISuggestionHeader-{{$course->course_id}}-{{$courseProgram->program_id}}"
+                                                              class="btn btn-sm btn-primary {{ $_aiBtnClass }} me-3 col-2 justify-content-center"
+                                                              role="button"
+                                                              data-toggle="modal" data-target="#AiSuggestionConfirmation{{$course->course_id}}{{$courseProgram->program_id}}">
                                                             <img src="{{ asset('img/AISuggestionWhite.png') }}" alt="icon" style="height: 1em; width: auto;" class="me-1">
                                                             AI Suggestion
                                                         </span>
+                                                        <!-- AI status container (shown while polling for results) -->
+                                                        <div id="aiStatusHeader-{{$course->course_id}}-{{$courseProgram->program_id}}"
+                                                             class="{{ $_aiStatusClass }} align-items-center me-3"
+                                                             {!! $_pollAttrs !!}>
+                                                            <button id="aiCheckingHeader-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-secondary" disabled>
+                                                                <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                                                Checking for results...
+                                                            </button>
+                                                            <button id="aiRefreshHeader-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-warning d-none"
+                                                                    onclick="refreshAiSuggestions({{$course->course_id}}, {{$courseProgram->program_id}})">
+                                                                <i class="bi bi-arrow-clockwise me-1"></i>
+                                                                Refresh AI Suggestions
+                                                            </button>
+                                                        </div>
                                                     @endif
                                                 </h2>
                                                 <!-- Program Accordion body -->
@@ -142,12 +162,36 @@
                                                             </div>
                                                             @if ($courseProgram->programLearningOutcomes->count() > 0)
 
-                                                                <div id="mappingOptions-{{$course->course_id}}-{{$courseProgram->program_id}}" class="justify-content-center gap-2 @if($courseProgram->pivot->manual_map_status) d-none @else d-flex @endif">
+                                                                @php
+                                                                    $_inFlightCenter      = isset($aiSuggestionInFlight) && !empty($aiSuggestionInFlight[$courseProgram->program_id]);
+                                                                    $_mappingOptionsHide  = ($courseProgram->pivot->manual_map_status || $_inFlightCenter);
+                                                                    $_mappingOptionsClass = $_mappingOptionsHide ? 'd-none' : 'd-flex';
+                                                                    $_centerStatusClass   = $_inFlightCenter ? 'd-flex' : 'd-none';
+                                                                    $_centerPollAttrs     = $_inFlightCenter ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
+                                                                    $_msgClass            = $_inFlightCenter ? 'small text-muted text-center mt-2 mb-0' : 'd-none small text-muted text-center mt-2 mb-0';
+                                                                    $_msgText             = $_inFlightCenter ? 'An AI suggestion request is already in progress for this course/program. You can leave this page - results will appear automatically when ready.' : '';
+                                                                @endphp
+                                                                <div id="mappingOptions-{{$course->course_id}}-{{$courseProgram->program_id}}" class="{{ $_mappingOptionsClass }} justify-content-center gap-2">
                                                                     <button id="buttonManualMap[{{$course->course_id}}][{{$courseProgram->program_id}}]" type="button" class="btn btn-sm btn-primary col-3 py-2" onclick="showManualMapDiv({{$course->course_id}}, {{$courseProgram->program_id}})">Create Manually</button>
-                                                                    <button id="buttonAISuggestion[{{$course->course_id}}][{{$courseProgram->program_id}}]" type="button" class="btn btn-sm btn-primary col-3 py-2"
+                                                                    <button id="buttonAISuggestionCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-primary col-3 py-2"
                                                                             data-toggle="modal" data-target="#AiSuggestionConfirmation{{$course->course_id}}{{$courseProgram->program_id}}">
                                                                         <img src="{{asset('img/AISuggestionWhite.png')}}" alt="icon" style="height: 1.5em; width: auto;" class="me-2">AI Suggestions</button>
                                                                 </div>
+                                                                <!-- AI status container (shown while polling for results) -->
+                                                                <div id="aiStatusCenter-{{$course->course_id}}-{{$courseProgram->program_id}}"
+                                                                     class="{{ $_centerStatusClass }} justify-content-center gap-2"
+                                                                     {!! $_centerPollAttrs !!}>
+                                                                    <button id="aiCheckingCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-secondary col-3 py-2" disabled>
+                                                                        <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                                                                        Checking for results...
+                                                                    </button>
+                                                                    <button id="aiRefreshCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-warning col-3 py-2 d-none"
+                                                                            onclick="refreshAiSuggestions({{$course->course_id}}, {{$courseProgram->program_id}})">
+                                                                        <i class="bi bi-arrow-clockwise me-2"></i>
+                                                                        Refresh AI Suggestions
+                                                                    </button>
+                                                                </div>
+                                                                <p id="aiStatusMessage-{{$course->course_id}}-{{$courseProgram->program_id}}" class="{{ $_msgClass }}">{{ $_msgText }}</p>
                                                                 <!-- list of course learning outcome accordions with mapping form -->
                                                                 <div id= "ManualMapBody-{{$course->course_id}}-{{$courseProgram->program_id}}" class="cloAccordions mb-4" @if(!$courseProgram->pivot->manual_map_status) style="display: none;" @endif>
                                                                     @foreach($l_outcomes as $index => $courseLearningOutcome)
@@ -394,6 +438,22 @@
             add();
         });
 
+        // Auto-resume polling for any (course, program) that was rendered with an
+        // in-flight AI suggestion request (rendered in the "Checking..." state by Blade).
+        // This handles: same-user-navigated-back, different-user-on-same-page.
+        const startedPairs = new Set();
+        document.querySelectorAll('[data-poll-on-load="true"]').forEach((el) => {
+            const courseId = el.getAttribute('data-course-id');
+            const programId = el.getAttribute('data-program-id');
+            if (!courseId || !programId) return;
+            const key = `${courseId}-${programId}`;
+            if (startedPairs.has(key)) return;
+            startedPairs.add(key);
+            // Both the header and center status containers can carry the same data
+            // attributes; Set dedupes so we only kick off one polling loop per pair.
+            pollForResults(parseInt(courseId, 10), parseInt(programId, 10));
+        });
+
         // $("form").submit(function (e) {
         //     // prevent duplicate form submissions
         //     e.preventDefault();
@@ -508,11 +568,122 @@
             container.append(element);
     }
 
-    function generateAiSuggestions(courseId, programId) {
+    const AI_POLL_INTERVAL_MS = 5000;
+    const AI_POLL_MAX_ATTEMPTS = 120; // ~10 minutes
+
+    const AI_MSG_CHECKING =
+        "Generating AI suggestions can take some time depending on how many PLOs and CLOs there are. " +
+        "You can safely leave this page - your suggestions will be saved when ready " +
+        "and will appear automatically the next time you open this page.";
+
+    const AI_MSG_TIMED_OUT =
+        "This is taking longer than usual. Click Refresh to check again, " +
+        "or come back later - your suggestions will appear automatically when ready.";
+
+    function hideAiModal(courseId, programId) {
+        const modalEl = document.getElementById(`AiSuggestionConfirmation${courseId}${programId}`);
+        if (!modalEl) return;
+        if (window.bootstrap && bootstrap.Modal) {
+            const inst = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
+            inst.hide();
+        } else if (window.jQuery && jQuery(modalEl).modal) {
+            jQuery(modalEl).modal('hide');
+        }
+    }
+
+    function setHidden(el, hidden) {
+        if (!el) return;
+        if (hidden) {
+            el.classList.add('d-none');
+            el.classList.remove('d-flex');
+        } else {
+            el.classList.remove('d-none');
+            el.classList.add('d-flex');
+        }
+    }
+
+    function enterCheckingState(courseId, programId, message) {
+        // Hide both AI Suggestion buttons
+        const aiBtnHeader = document.getElementById(`buttonAISuggestionHeader-${courseId}-${programId}`);
+        const aiBtnCenter = document.getElementById(`buttonAISuggestionCenter-${courseId}-${programId}`);
+        if (aiBtnHeader) aiBtnHeader.classList.add('d-none');
+        if (aiBtnCenter) aiBtnCenter.classList.add('d-none');
+
+        // Show status containers
+        setHidden(document.getElementById(`aiStatusHeader-${courseId}-${programId}`), false);
+        setHidden(document.getElementById(`aiStatusCenter-${courseId}-${programId}`), false);
+
+        // Show "Checking..." button, hide "Refresh" button in both locations
+        ['Header', 'Center'].forEach(loc => {
+            const checking = document.getElementById(`aiChecking${loc}-${courseId}-${programId}`);
+            const refresh  = document.getElementById(`aiRefresh${loc}-${courseId}-${programId}`);
+            if (checking) checking.classList.remove('d-none');
+            if (refresh)  refresh.classList.add('d-none');
+        });
+
+        // Show status message
+        const msgEl = document.getElementById(`aiStatusMessage-${courseId}-${programId}`);
+        if (msgEl) {
+            msgEl.textContent = message;
+            msgEl.classList.remove('d-none');
+        }
+    }
+
+    function enterTimedOutState(courseId, programId) {
+        // Hide "Checking..." button, show "Refresh" button in both locations
+        ['Header', 'Center'].forEach(loc => {
+            const checking = document.getElementById(`aiChecking${loc}-${courseId}-${programId}`);
+            const refresh  = document.getElementById(`aiRefresh${loc}-${courseId}-${programId}`);
+            if (checking) checking.classList.add('d-none');
+            if (refresh)  refresh.classList.remove('d-none');
+        });
+
+        const msgEl = document.getElementById(`aiStatusMessage-${courseId}-${programId}`);
+        if (msgEl) {
+            msgEl.textContent = AI_MSG_TIMED_OUT;
+            msgEl.classList.remove('d-none');
+        }
+    }
+
+    function refreshAiSuggestions(courseId, programId) {
+        enterCheckingState(courseId, programId, AI_MSG_CHECKING);
+        pollForResults(courseId, programId);
+    }
+
+    async function generateAiSuggestions(courseId, programId) {
         const yesButton = event.target;
         yesButton.disabled = true;
         const originalText = yesButton.innerHTML;
-        yesButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+        yesButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Submitting...';
+
+        // Pre-click in-flight check: catches the race where another user (or this user
+        // in another tab) already submitted in the seconds between page render and click.
+        try {
+            const checkRes = await fetch(`/courseWizard/${courseId}/${programId}/check-in-flight`, {
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify({}),
+            });
+            if (checkRes.ok) {
+                const checkData = await checkRes.json();
+                if (checkData.in_flight) {
+                    hideAiModal(courseId, programId);
+                    enterCheckingState(courseId, programId,
+                        "An AI suggestion request was already submitted (possibly by another user). " +
+                        "Polling for results - this can take some time.");
+                    pollForResults(courseId, programId);
+                    yesButton.disabled = false;
+                    yesButton.innerHTML = originalText;
+                    return;
+                }
+            }
+        } catch (err) {
+            console.warn('Pre-click in-flight check failed, proceeding with submission:', err);
+        }
 
         fetch(`/courseWizard/${courseId}/${programId}/generate-ai-suggestions`, {
             method: 'POST',
@@ -535,20 +706,17 @@
         .then(data => {
             console.log('AI suggestion response:', data);
 
-            if (data.status === 'mock') {
-                alert('Mock AI suggestions generated! (Testing mode)\n\nRequest ID: ' + data.request_id);
-                $(`#AiSuggestionConfirmation${courseId}${programId}`).modal('hide');
-            } else if (data.status === 'success') {
-                alert('AI suggestion request submitted successfully!\n\nJob Name: ' + data.job_name);
-                $(`#AiSuggestionConfirmation${courseId}${programId}`).modal('hide');
-                pollForResults(courseId, programId, data.request_id);
+            if (data.status === 'mock' || data.status === 'success') {
+                hideAiModal(courseId, programId);
+                enterCheckingState(courseId, programId, AI_MSG_CHECKING);
+                pollForResults(courseId, programId);
             } else {
                 throw new Error(data.message || 'Unknown error');
             }
         })
         .catch(error => {
             console.error('Error:', error);
-            alert('Error generating AI suggestions: ' + error.message);
+            alert('Error generating AI suggestions: ' + error.message + '\n\nPlease try again.');
         })
         .finally(() => {
             yesButton.disabled = false;
@@ -556,8 +724,7 @@
         });
     }
 
-    function pollForResults(courseId, programId, requestId) {
-        const maxAttempts = 120;
+    function pollForResults(courseId, programId) {
         let attempts = 0;
 
         const interval = setInterval(async () => {
@@ -570,7 +737,7 @@
                         'Content-Type': 'application/json',
                         'Accept': 'application/json',
                     },
-                    body: JSON.stringify({ request_id: requestId }),
+                    body: JSON.stringify({ course_id: courseId, program_id: programId }),
                 });
 
                 if (!response.ok) {
@@ -582,14 +749,18 @@
                 if (data.status === 'complete') {
                     clearInterval(interval);
                     window.location.reload();
-                } else if (attempts >= maxAttempts) {
+                } else if (attempts >= AI_POLL_MAX_ATTEMPTS) {
                     clearInterval(interval);
-                    alert('AI suggestion generation timed out. Please try again.');
+                    enterTimedOutState(courseId, programId);
                 }
             } catch (err) {
                 console.error('Polling error:', err);
+                if (attempts >= AI_POLL_MAX_ATTEMPTS) {
+                    clearInterval(interval);
+                    enterTimedOutState(courseId, programId);
+                }
             }
-        }, 5000);
+        }, AI_POLL_INTERVAL_MS);
     }
 
 </script>

--- a/laravel/resources/views/courses/wizard/step5.blade.php
+++ b/laravel/resources/views/courses/wizard/step5.blade.php
@@ -580,11 +580,27 @@
         "This is taking longer than usual. Click Refresh to check again, " +
         "or come back later - your suggestions will appear automatically when ready.";
 
+    function closeModal(modalEl) {
+        if (!modalEl) return;
+        modalEl.classList.remove('show');
+        modalEl.style.display = 'none';
+        modalEl.setAttribute('aria-hidden', 'true');
+        modalEl.removeAttribute('aria-modal');
+        modalEl.removeAttribute('role');
+        document.body.classList.remove('modal-open');
+        document.body.style.removeProperty('padding-right');
+        document.body.style.removeProperty('overflow');
+        document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+    }
+
+    document.addEventListener('click', function (e) {
+        const trigger = e.target.closest('[data-dismiss="modal"], [data-bs-dismiss="modal"]');
+        if (!trigger) return;
+        closeModal(trigger.closest('.modal'));
+    });
+
     function hideAiModal(courseId, programId) {
-        const modalEl = document.getElementById(`AiSuggestionConfirmation${courseId}${programId}`);
-        if (modalEl && window.jQuery) {
-            jQuery(modalEl).modal('hide');
-        }
+        closeModal(document.getElementById(`AiSuggestionConfirmation${courseId}${programId}`));
     }
 
     function setHidden(el, hidden) {

--- a/laravel/resources/views/courses/wizard/step5.blade.php
+++ b/laravel/resources/views/courses/wizard/step5.blade.php
@@ -72,7 +72,7 @@
                                                         </div>
                                                         <div class="modal-footer">
                                                             <button style="width:60px" type="button" class="btn btn-secondary btn-sm" data-dismiss="modal">No</button>
-                                                            <button style="width:80px" type="button" class="btn btn-success btn-sm">Yes</button>
+                                                            <button style="width:80px" type="button" class="btn btn-success btn-sm" onclick="generateAiSuggestions({{$course->course_id}}, {{$courseProgram->program_id}})">Yes</button>
                                                         </div>
                                                 </div>
                                             </div>
@@ -506,6 +506,90 @@
             </tr>`;
             var container = $('#highOpportunityTable tbody');
             container.append(element);
+    }
+
+    function generateAiSuggestions(courseId, programId) {
+        const yesButton = event.target;
+        yesButton.disabled = true;
+        const originalText = yesButton.innerHTML;
+        yesButton.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+
+        fetch(`/courseWizard/${courseId}/${programId}/generate-ai-suggestions`, {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({
+                course_id: courseId,
+                program_id: programId,
+            })
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            console.log('AI suggestion response:', data);
+
+            if (data.status === 'mock') {
+                alert('Mock AI suggestions generated! (Testing mode)\n\nRequest ID: ' + data.request_id);
+                $(`#AiSuggestionConfirmation${courseId}${programId}`).modal('hide');
+            } else if (data.status === 'success') {
+                alert('AI suggestion request submitted successfully!\n\nJob Name: ' + data.job_name);
+                $(`#AiSuggestionConfirmation${courseId}${programId}`).modal('hide');
+                pollForResults(courseId, programId, data.request_id);
+            } else {
+                throw new Error(data.message || 'Unknown error');
+            }
+        })
+        .catch(error => {
+            console.error('Error:', error);
+            alert('Error generating AI suggestions: ' + error.message);
+        })
+        .finally(() => {
+            yesButton.disabled = false;
+            yesButton.innerHTML = originalText;
+        });
+    }
+
+    function pollForResults(courseId, programId, requestId) {
+        const maxAttempts = 120;
+        let attempts = 0;
+
+        const interval = setInterval(async () => {
+            attempts++;
+            try {
+                const response = await fetch(`/courseWizard/${courseId}/${programId}/check-ai-results`, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify({ request_id: requestId }),
+                });
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+
+                if (data.status === 'complete') {
+                    clearInterval(interval);
+                    window.location.reload();
+                } else if (attempts >= maxAttempts) {
+                    clearInterval(interval);
+                    alert('AI suggestion generation timed out. Please try again.');
+                }
+            } catch (err) {
+                console.error('Polling error:', err);
+            }
+        }, 5000);
     }
 
 </script>

--- a/laravel/resources/views/courses/wizard/step5.blade.php
+++ b/laravel/resources/views/courses/wizard/step5.blade.php
@@ -164,31 +164,28 @@
 
                                                                 @php
                                                                     $_inFlightCenter      = isset($aiSuggestionInFlight) && !empty($aiSuggestionInFlight[$courseProgram->program_id]);
-                                                                    // Mapping options row is hidden only when manual mapping has started.
-                                                                    // During in-flight, "Create Manually" stays available; only the AI Suggestions
-                                                                    // button below is hidden in favour of the Checking/Refresh status.
                                                                     $_mappingOptionsClass = $courseProgram->pivot->manual_map_status ? 'd-none' : 'd-flex';
-                                                                    $_aiSuggestionsBtnClass = $_inFlightCenter ? 'd-none' : 'd-inline-block';
-                                                                    $_centerStatusClass   = $_inFlightCenter ? 'd-flex' : 'd-none';
-                                                                    $_centerPollAttrs     = $_inFlightCenter ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
-                                                                    $_msgClass            = $_inFlightCenter ? 'small text-muted text-center mt-2 mb-0' : 'd-none small text-muted text-center mt-2 mb-0';
-                                                                    $_msgText             = $_inFlightCenter ? 'An AI suggestion request is already in progress for this course/program. You can leave this page - results will appear automatically when ready.' : '';
+                                                                    // All four buttons live in one flex row; toggle visibility per-button so
+                                                                    // they sit side-by-side instead of stacking vertically.
+                                                                    $_aiSuggestionsBtnHidden = $_inFlightCenter;
+                                                                    $_checkingBtnHidden      = !$_inFlightCenter;
+                                                                    $_refreshBtnHidden       = true; // JS shows this only after a polling timeout
+                                                                    $_pollAttrs              = $_inFlightCenter ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
+                                                                    $_msgClass               = $_inFlightCenter ? 'small text-muted text-center mt-2 mb-0' : 'd-none small text-muted text-center mt-2 mb-0';
+                                                                    $_msgText                = $_inFlightCenter ? 'An AI suggestion request is already in progress for this course/program. You can leave this page - results will appear automatically when ready.' : '';
                                                                 @endphp
-                                                                <div id="mappingOptions-{{$course->course_id}}-{{$courseProgram->program_id}}" class="{{ $_mappingOptionsClass }} justify-content-center gap-2">
+                                                                <div id="mappingOptions-{{$course->course_id}}-{{$courseProgram->program_id}}"
+                                                                     class="{{ $_mappingOptionsClass }} justify-content-center gap-2"
+                                                                     {!! $_pollAttrs !!}>
                                                                     <button id="buttonManualMap[{{$course->course_id}}][{{$courseProgram->program_id}}]" type="button" class="btn btn-sm btn-primary col-3 py-2" onclick="showManualMapDiv({{$course->course_id}}, {{$courseProgram->program_id}})">Create Manually</button>
-                                                                    <button id="buttonAISuggestionCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-primary col-3 py-2 {{ $_aiSuggestionsBtnClass }}"
+                                                                    <button id="buttonAISuggestionCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-primary col-3 py-2 {{ $_aiSuggestionsBtnHidden ? 'd-none' : '' }}"
                                                                             data-toggle="modal" data-target="#AiSuggestionConfirmation{{$course->course_id}}{{$courseProgram->program_id}}">
                                                                         <img src="{{asset('img/AISuggestionWhite.png')}}" alt="icon" style="height: 1.5em; width: auto;" class="me-2">AI Suggestions</button>
-                                                                </div>
-                                                                <!-- AI status container (shown while polling for results) -->
-                                                                <div id="aiStatusCenter-{{$course->course_id}}-{{$courseProgram->program_id}}"
-                                                                     class="{{ $_centerStatusClass }} justify-content-center gap-2"
-                                                                     {!! $_centerPollAttrs !!}>
-                                                                    <button id="aiCheckingCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-secondary col-3 py-2" disabled>
+                                                                    <button id="aiCheckingCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-secondary col-3 py-2 {{ $_checkingBtnHidden ? 'd-none' : '' }}" disabled>
                                                                         <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
                                                                         Waiting for AI suggestions...
                                                                     </button>
-                                                                    <button id="aiRefreshCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-warning col-3 py-2 d-none"
+                                                                    <button id="aiRefreshCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-warning col-3 py-2 {{ $_refreshBtnHidden ? 'd-none' : '' }}"
                                                                             onclick="refreshAiSuggestions({{$course->course_id}}, {{$courseProgram->program_id}})">
                                                                         <i class="bi bi-arrow-clockwise me-2"></i>
                                                                         Refresh AI Suggestions
@@ -585,11 +582,7 @@
 
     function hideAiModal(courseId, programId) {
         const modalEl = document.getElementById(`AiSuggestionConfirmation${courseId}${programId}`);
-        if (!modalEl) return;
-        if (window.bootstrap && bootstrap.Modal) {
-            const inst = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
-            inst.hide();
-        } else if (window.jQuery && jQuery(modalEl).modal) {
+        if (modalEl && window.jQuery) {
             jQuery(modalEl).modal('hide');
         }
     }
@@ -606,17 +599,13 @@
     }
 
     function enterCheckingState(courseId, programId, message) {
-        // Hide both AI Suggestion buttons
         const aiBtnHeader = document.getElementById(`buttonAISuggestionHeader-${courseId}-${programId}`);
         const aiBtnCenter = document.getElementById(`buttonAISuggestionCenter-${courseId}-${programId}`);
         if (aiBtnHeader) aiBtnHeader.classList.add('d-none');
         if (aiBtnCenter) aiBtnCenter.classList.add('d-none');
 
-        // Show status containers
         setHidden(document.getElementById(`aiStatusHeader-${courseId}-${programId}`), false);
-        setHidden(document.getElementById(`aiStatusCenter-${courseId}-${programId}`), false);
 
-        // Show "Checking..." button, hide "Refresh" button in both locations
         ['Header', 'Center'].forEach(loc => {
             const checking = document.getElementById(`aiChecking${loc}-${courseId}-${programId}`);
             const refresh  = document.getElementById(`aiRefresh${loc}-${courseId}-${programId}`);
@@ -624,7 +613,6 @@
             if (refresh)  refresh.classList.add('d-none');
         });
 
-        // Show status message
         const msgEl = document.getElementById(`aiStatusMessage-${courseId}-${programId}`);
         if (msgEl) {
             msgEl.textContent = message;
@@ -633,7 +621,6 @@
     }
 
     function enterTimedOutState(courseId, programId) {
-        // Hide "Checking..." button, show "Refresh" button in both locations
         ['Header', 'Center'].forEach(loc => {
             const checking = document.getElementById(`aiChecking${loc}-${courseId}-${programId}`);
             const refresh  = document.getElementById(`aiRefresh${loc}-${courseId}-${programId}`);

--- a/laravel/resources/views/courses/wizard/step5.blade.php
+++ b/laravel/resources/views/courses/wizard/step5.blade.php
@@ -114,7 +114,7 @@
                                                              {!! $_pollAttrs !!}>
                                                             <button id="aiCheckingHeader-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-secondary" disabled>
                                                                 <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
-                                                                Checking for results...
+                                                                Waiting for AI suggestions...
                                                             </button>
                                                             <button id="aiRefreshHeader-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-warning d-none"
                                                                     onclick="refreshAiSuggestions({{$course->course_id}}, {{$courseProgram->program_id}})">
@@ -164,8 +164,11 @@
 
                                                                 @php
                                                                     $_inFlightCenter      = isset($aiSuggestionInFlight) && !empty($aiSuggestionInFlight[$courseProgram->program_id]);
-                                                                    $_mappingOptionsHide  = ($courseProgram->pivot->manual_map_status || $_inFlightCenter);
-                                                                    $_mappingOptionsClass = $_mappingOptionsHide ? 'd-none' : 'd-flex';
+                                                                    // Mapping options row is hidden only when manual mapping has started.
+                                                                    // During in-flight, "Create Manually" stays available; only the AI Suggestions
+                                                                    // button below is hidden in favour of the Checking/Refresh status.
+                                                                    $_mappingOptionsClass = $courseProgram->pivot->manual_map_status ? 'd-none' : 'd-flex';
+                                                                    $_aiSuggestionsBtnClass = $_inFlightCenter ? 'd-none' : 'd-inline-block';
                                                                     $_centerStatusClass   = $_inFlightCenter ? 'd-flex' : 'd-none';
                                                                     $_centerPollAttrs     = $_inFlightCenter ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
                                                                     $_msgClass            = $_inFlightCenter ? 'small text-muted text-center mt-2 mb-0' : 'd-none small text-muted text-center mt-2 mb-0';
@@ -173,7 +176,7 @@
                                                                 @endphp
                                                                 <div id="mappingOptions-{{$course->course_id}}-{{$courseProgram->program_id}}" class="{{ $_mappingOptionsClass }} justify-content-center gap-2">
                                                                     <button id="buttonManualMap[{{$course->course_id}}][{{$courseProgram->program_id}}]" type="button" class="btn btn-sm btn-primary col-3 py-2" onclick="showManualMapDiv({{$course->course_id}}, {{$courseProgram->program_id}})">Create Manually</button>
-                                                                    <button id="buttonAISuggestionCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-primary col-3 py-2"
+                                                                    <button id="buttonAISuggestionCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-primary col-3 py-2 {{ $_aiSuggestionsBtnClass }}"
                                                                             data-toggle="modal" data-target="#AiSuggestionConfirmation{{$course->course_id}}{{$courseProgram->program_id}}">
                                                                         <img src="{{asset('img/AISuggestionWhite.png')}}" alt="icon" style="height: 1.5em; width: auto;" class="me-2">AI Suggestions</button>
                                                                 </div>
@@ -183,7 +186,7 @@
                                                                      {!! $_centerPollAttrs !!}>
                                                                     <button id="aiCheckingCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-secondary col-3 py-2" disabled>
                                                                         <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
-                                                                        Checking for results...
+                                                                        Waiting for AI suggestions...
                                                                     </button>
                                                                     <button id="aiRefreshCenter-{{$course->course_id}}-{{$courseProgram->program_id}}" type="button" class="btn btn-sm btn-warning col-3 py-2 d-none"
                                                                             onclick="refreshAiSuggestions({{$course->course_id}}, {{$courseProgram->program_id}})">

--- a/laravel/resources/views/courses/wizard/step5.blade.php
+++ b/laravel/resources/views/courses/wizard/step5.blade.php
@@ -94,12 +94,13 @@
                                                     </button>
 
                                                     <!-- AI Suggestion button -->
-                                                    @if(!$courseProgram->pivot->ai_suggestion_status and $courseProgram->pivot->manual_map_status)
+                                                    @if(!$courseProgram->pivot->ai_suggestion_status)
                                                         @php
-                                                            $_inFlight = isset($aiSuggestionInFlight) && !empty($aiSuggestionInFlight[$courseProgram->program_id]);
-                                                            $_aiBtnClass     = $_inFlight ? 'd-none' : 'd-flex';
-                                                            $_aiStatusClass  = $_inFlight ? 'd-flex' : 'd-none';
-                                                            $_pollAttrs      = $_inFlight ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
+                                                            $_inFlight         = isset($aiSuggestionInFlight) && !empty($aiSuggestionInFlight[$courseProgram->program_id]);
+                                                            $_manualMapStarted = (bool) $courseProgram->pivot->manual_map_status;
+                                                            $_aiBtnClass     = ($_manualMapStarted && !$_inFlight) ? 'd-flex' : 'd-none';
+                                                            $_aiStatusClass  = ($_manualMapStarted && $_inFlight)  ? 'd-flex' : 'd-none';
+                                                            $_pollAttrs      = ($_manualMapStarted && $_inFlight)  ? sprintf('data-poll-on-load="true" data-course-id="%d" data-program-id="%d"', $course->course_id, $courseProgram->program_id) : '';
                                                         @endphp
                                                         <span id="buttonAISuggestionHeader-{{$course->course_id}}-{{$courseProgram->program_id}}"
                                                               class="btn btn-sm btn-primary {{ $_aiBtnClass }} me-3 col-2 justify-content-center"
@@ -544,6 +545,12 @@
                 div.classList.remove('d-flex');
 
                 document.getElementById(`ManualMapBody-${course_id}-${program_id}`).style.display = "block";
+
+                const inFlight = div.getAttribute('data-poll-on-load') === 'true';
+                const headerBtn    = document.getElementById(`buttonAISuggestionHeader-${course_id}-${program_id}`);
+                const headerStatus = document.getElementById(`aiStatusHeader-${course_id}-${program_id}`);
+                setHidden(headerBtn,    inFlight);
+                setHidden(headerStatus, !inFlight);
             }).catch(error => {
                 console.error('Unable to enable manual mapping:', error);
                 alert('We could not open manual mapping right now. Please try again later.');

--- a/laravel/routes/api.php
+++ b/laravel/routes/api.php
@@ -17,3 +17,11 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+// Endpoints called by Python microservices. Group routes by source service so each one's
+// concerns stay isolated and future services (e.g. syllabi) can add their own without collisions.
+Route::prefix('microservices')->group(function () {
+    Route::prefix('lo-mapping')->group(function () {
+        Route::post('/ai-suggestions/store', [\App\Http\Controllers\CourseProgramController::class, 'storeAiSuggestions']);
+    });
+});

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -254,6 +254,8 @@ Route::get('/courseWizard/{course}/step8', [CourseWizardController::class, 'step
 Route::post('courseWizard/{courseId}/{programId}/manualMap', [CourseProgramController::class, 'updateManualMapStatus']);
 Route::post('courseWizard/{courseId}/{programId}/aiSuggestion', [CourseProgramController::class, 'updateAiSuggestionStatus']);
 Route::post('courseWizard/{courseId}/{programId}/generate-ai-suggestions', [CourseProgramController::class, 'generateAiSuggestions']);
+Route::post('courseWizard/{courseId}/{programId}/check-ai-results', [CourseProgramController::class, 'checkAiResults']);
+Route::post('courseWizard/{courseId}/{programId}/check-in-flight', [CourseProgramController::class, 'checkInFlight']);
 
 Route::post('/courseDescription/{course}/store', [\App\Http\Controllers\CourseDescriptionController::class, 'store'])->name('courseDescription.store');
 

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -253,6 +253,7 @@ Route::get('/courseWizard/{course}/step7', [CourseWizardController::class, 'step
 Route::get('/courseWizard/{course}/step8', [CourseWizardController::class, 'step8'])->name('courseWizard.step8');
 Route::post('courseWizard/{courseId}/{programId}/manualMap', [CourseProgramController::class, 'updateManualMapStatus']);
 Route::post('courseWizard/{courseId}/{programId}/aiSuggestion', [CourseProgramController::class, 'updateAiSuggestionStatus']);
+Route::post('courseWizard/{courseId}/{programId}/generate-ai-suggestions', [CourseProgramController::class, 'generateAiSuggestions']);
 
 Route::post('/courseDescription/{course}/store', [\App\Http\Controllers\CourseDescriptionController::class, 'store'])->name('courseDescription.store');
 

--- a/python/services/lo_mapping_service/app/api/routes.py
+++ b/python/services/lo_mapping_service/app/api/routes.py
@@ -11,7 +11,8 @@ import os
 
 from app.schemas import (
     OutcomeMappingRequest,
-    ManualProcessRequest
+    ManualProcessRequest,
+    InFlightStatusRequest,
 )
 from app.services import BatchTransformInputBuilder, LOMappingRequestDynamoDBRecord, process_batch_transform_results
 from app.services.scheduled_job import create_scheduler
@@ -68,6 +69,24 @@ async def health_check() -> dict[str, str]:
 @app.post("/map-program-outcomes")
 async def map_program_outcomes(request: OutcomeMappingRequest)-> dict:
     try:
+        # Dedupe: if there is already an in-flight record for this (course, program)
+        # pair, return its request_id and skip the S3 upload + DynamoDB insert + Lambda
+        # invoke. Best-effort (small race window between query and insert).
+        existing = lo_mapping_request_store.find_in_flight_records_for_pairs(
+            [(request.course_id, request.program_id)]
+        ).get((request.course_id, request.program_id))
+        if existing is not None:
+            logger.info(
+                "Dedupe: existing in-flight record found for course_id=%s program_id=%s status=%s — reusing.",
+                request.course_id, request.program_id, existing.get("status"),
+            )
+            return {
+                "message": "Existing request in flight for this course/program, reusing it.",
+                "jobName": existing.get("transform_job_name"),
+                "startedForRecordId": existing.get("request_id"),
+                "deduplicated": True,
+            }
+
         batchTranformInputBuilder = BatchTransformInputBuilder(request)
         s3_input_path = batchTranformInputBuilder.build_batch_prompt_records()
         record = lo_mapping_request_store.create_request(
@@ -88,11 +107,12 @@ async def map_program_outcomes(request: OutcomeMappingRequest)-> dict:
                 raise HTTPException(status_code=500, detail="Lambda invocation failed")
 
             result = json.loads(response["Payload"].read())
+            body = result.get("body", {}) if isinstance(result, dict) else {}
 
             return {
-                "message": result["body"]["message"],
-                "jobName": result["body"]["jobName"],
-                "startedForRecordId": result["body"]["startedForRecordId"],
+                "message": body.get("message", "Submitted"),
+                "jobName": body.get("jobName") or body.get("existingJob"),
+                "startedForRecordId": body.get("startedForRecordId") or record["request_id"],
             }
 
         except Exception as e:
@@ -101,51 +121,95 @@ async def map_program_outcomes(request: OutcomeMappingRequest)-> dict:
         logger.error(f"Error in mapping LOs: {e}")
         raise HTTPException(status_code=500, detail="Something went wrong while processing mapping request")
     
+@app.post("/in-flight-status")
+async def in_flight_status(request: InFlightStatusRequest) -> dict:
+    """
+    For each (course_id, program_id) pair in the request, return whether an
+    in-flight DynamoDB record exists (any status not yet delivered to Laravel
+    and deleted).
+
+    Used by Laravel both at Step 5 page render time (to render the right state
+    for each program) and right before submitting a new request (race-safe pre-check).
+    """
+    pairs = [(p.course_id, p.program_id) for p in request.pairs]
+    records_by_pair = lo_mapping_request_store.find_in_flight_records_for_pairs(pairs)
+
+    statuses = []
+    for pair in pairs:
+        record = records_by_pair.get(pair)
+        if record is None:
+            statuses.append({
+                "course_id": pair[0],
+                "program_id": pair[1],
+                "in_flight": False,
+            })
+        else:
+            statuses.append({
+                "course_id": pair[0],
+                "program_id": pair[1],
+                "in_flight": True,
+                "status": record.get("status"),
+                "request_id": record.get("request_id"),
+                "created_at": record.get("created_at"),
+            })
+    return {"statuses": statuses}
+
+
 @app.post("/process-batch-transform-results")
 async def process_batch_transform_results_endpoint(request: dict, background_tasks: BackgroundTasks) -> dict:
     # To ensure lambda_handler_process_batch_transform_inference_results does not wait for it to complete
     background_tasks.add_task(process_batch_transform_results.process_records, request["recordsAwaitingProcessing"])
     return {"message": "accepted"}
 
-@app.post("/get-processed-results")
-async def manually_trigger_processing(body: ManualProcessRequest):
+@app.post("/poll-results-status")
+async def poll_results_status(body: ManualProcessRequest):
+    """Read-only check: is there an AWAITING_COMPLETION record ready to process?"""
+    record = lo_mapping_request_store.find_latest_awaiting_record_by_ids(
+        body.course_id, body.program_id
+    )
+    if not record:
+        return {"status": "pending"}
+    return {
+        "status":     "ready_to_process",
+        "record_id":  record.get("request_id"),
+        "record_status": record.get("status"),
+    }
+
+
+@app.post("/process-pending-results")
+async def process_pending_results(body: ManualProcessRequest, background_tasks: BackgroundTasks):
     """
-    Called by Laravel when it wants results for a given course_id + program_id.
- 
-    - Finds the latest DynamoDB record in AWAITING_COMPLETION or AWAITING_COMPLETION_FAILED status for the given course_id and program_id
-    - If found: runs post-processing and returns
-    - If not found: returns telling Laravel results are still being processed
+    Trigger S3 read + Laravel delivery + DynamoDB cleanup as a background task,
+    and return immediately. Returning fast prevents a circular-call deadlock when
+    Laravel is single-threaded (e.g. `php artisan serve` with one worker), since
+    this request has to finish before Laravel can serve the storeAiSuggestions
+    POST that the background task makes.
     """
     logger.info(
-        "Manually trigger processing request — course_id=%s program_id=%s",
+        "Process pending results request — course_id=%s program_id=%s",
         body.course_id, body.program_id,
     )
- 
-    record = lo_mapping_request_store.find_latest_awaiting_record_by_ids(body.course_id, body.program_id)
- 
-    if not record:
-        # Either still pending, processing or record doesn't exist
-        logger.info(
-            "No AWAITING_COMPLETION or AWAITING_COMPLETION_FAILED record found for course_id=%s program=%s — still processing.",
-            body.course_id, body.program,
-        )
-        return {
-            "status": "pending",
-            "message": "Results are still being processed. Please try again later.",
-        }
- 
-    record_id = record.get("request_id")
-    record_status = record.get("status")
-    logger.info(
-        "Found record '%s' with status '%s' — starting post-processing.",
-        record_id, record_status,
+
+    record = lo_mapping_request_store.find_latest_awaiting_record_by_ids(
+        body.course_id, body.program_id
     )
- 
-    await process_records([record])
- 
+    if not record:
+        return {
+            "status":  "pending",
+            "message": "No record ready to process for this course/program.",
+        }
+
+    background_tasks.add_task(process_records, [record])
     return {
-        "status": "ok",
-        "message": f"Results for course '{body.course_id}' / program '{body.program}' processed and sent.",
-        "record_id": record_id,
+        "status":    "processing_triggered",
+        "message":   "Processing started in background.",
+        "record_id": record.get("request_id"),
     }
+
+
+# Backwards-compatible alias for older callers (and the 6-hour scheduler invocation
+# pattern). Same behaviour as /process-pending-results.
+@app.post("/get-processed-results")
+async def get_processed_results_alias(body: ManualProcessRequest, background_tasks: BackgroundTasks):
+    return await process_pending_results(body, background_tasks)
     

--- a/python/services/lo_mapping_service/app/core/config.py
+++ b/python/services/lo_mapping_service/app/core/config.py
@@ -5,7 +5,7 @@ from pydantic import field_validator
 
 class Settings(BaseSettings):
     ALLOWED_ORIGINS: str = ""
-    LO_MAPPING_REQUESTS_TABLE: str | None = None
+    LO_MAPPING_DYNAMODB_REQUESTS_TABLE: str | None = None
     AWS_REGION: str | None = None
     ACCESS_KEY: str | None = None
     SECRET_KEY: str | None = None

--- a/python/services/lo_mapping_service/app/core/config.py
+++ b/python/services/lo_mapping_service/app/core/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     ACCESS_KEY: str | None = None
     SECRET_KEY: str | None = None
     DYNAMODB_STATUS_INDEX: str = "status-created_at-index"
+    OUTPUT_S3_URI: str | None = None
 
     @field_validator("ALLOWED_ORIGINS")
     def parse_allowed_origins(cls, v: str) -> List[str]:

--- a/python/services/lo_mapping_service/app/lambda_handlers/lambda_handler_process_batch_transform_inference_results.py
+++ b/python/services/lo_mapping_service/app/lambda_handlers/lambda_handler_process_batch_transform_inference_results.py
@@ -196,6 +196,17 @@ def lambda_handler(event, context) -> dict:
         logger.error("Missing TransformJobName or TransformJobStatus in event detail.")
         return {"statusCode": 400, "body": "Invalid EventBridge event."}
 
+    TERMINAL_STATES = {"Completed", "Failed", "Stopped"}
+    if job_status not in TERMINAL_STATES:
+        logger.info(
+            "Job '%s' is in non-terminal state '%s' - no action taken.",
+            job_name, job_status,
+        )
+        return {
+            "statusCode": 200,
+            "body": {"message": f"Non-terminal state '{job_status}' - no action taken."},
+        }
+
     logger.info("Job '%s' finished with status: %s", job_name, job_status)
 
     # course_id, program_id = parse_job_name(job_name)

--- a/python/services/lo_mapping_service/app/lambda_handlers/lambda_handler_start_batch_tranform_job.py
+++ b/python/services/lo_mapping_service/app/lambda_handlers/lambda_handler_start_batch_tranform_job.py
@@ -80,18 +80,24 @@ def get_running_transform_job() -> dict | None:
 
 
 def create_model(model_name: str):
-    
+    try:
+        sm.describe_model(ModelName=model_name)
+        logger.info("SageMaker model %s already exists, reusing it.", model_name)
+        return
+    except sm.exceptions.ClientError as e:
+        if e.response.get("Error", {}).get("Code") != "ValidationException":
+            raise
+
     sm.create_model(
         ModelName=model_name,
         PrimaryContainer={
             "Image": HF_IMAGE_URI,
-            "Environment": {
-                **hub_env
-            },
+            "Environment": {**hub_env},
         },
         ExecutionRoleArn=SAGEMAKER_ROLE_ARN,
     )
     logger.info("Created SageMaker model: %s", model_name)
+
 
 
 def start_transform_job(job_name, model_name, input_s3_uri):
@@ -200,6 +206,11 @@ def build_job_name(record) -> str:
     timestamp      = datetime.now().strftime("%Y%m%d%H%M%S")
     course_number  = record.get("course_id")
     program_number = record.get("program_id")
+    
+    if course_number is not None:
+        course_number = str(course_number)
+    if program_number is not None:
+        program_number = str(program_number)
 
     if _is_known(course_number) and _is_known(program_number):
         safe_course  = _sanitize_for_job_name(course_number)

--- a/python/services/lo_mapping_service/app/schemas.py
+++ b/python/services/lo_mapping_service/app/schemas.py
@@ -43,3 +43,12 @@ class OutcomeMappingRequest(BaseModel):
 class ManualProcessRequest(BaseModel):
     course_id: str
     program_id: str
+
+
+class CourseProgramPair(BaseModel):
+    course_id: int
+    program_id: int
+
+
+class InFlightStatusRequest(BaseModel):
+    pairs: List[CourseProgramPair]

--- a/python/services/lo_mapping_service/app/services/lo_mapping_request_dynamo_db_request.py
+++ b/python/services/lo_mapping_service/app/services/lo_mapping_request_dynamo_db_request.py
@@ -18,6 +18,7 @@ class LOMappingRequestDynamoDBRecord:
         self.aws_access_key = self.settings.ACCESS_KEY
         self.aws_secret_key = self.settings.SECRET_KEY
         self.status_index = self.settings.DYNAMODB_STATUS_INDEX
+        self.output_s3_uri = self.settings.OUTPUT_S3_URI
 
     def ensure_table_exists(self):
         if not self.table_name:
@@ -63,6 +64,14 @@ class LOMappingRequestDynamoDBRecord:
             raise ValueError("LO_MAPPING_DYNAMODB_REQUESTS_TABLE is not set")
         if not input_s3_path:
             raise ValueError("input_s3_path is required")
+        if not self.output_s3_uri:
+            raise ValueError("OUTPUT_S3_URI is not set")
+
+        # SageMaker writes outputs as <OUTPUT_S3_URI>/<input_filename>.out, so
+        # mirror that exactly rather than guessing from the input path.
+        output_prefix = self.output_s3_uri.rstrip("/")
+        input_filename = input_s3_path.rsplit("/", 1)[-1]
+        output_s3_path = f"{output_prefix}/{input_filename}.out"
 
         item = {
             "request_id": datetime.now().strftime('%Y%m%d-%H%M%S-') + str(uuid4()), # Generate based on datetime to ensure uniqueness
@@ -70,7 +79,7 @@ class LOMappingRequestDynamoDBRecord:
             "program_id": program_id,
             "status": status,
             "input_s3_path": input_s3_path,
-            "output_s3_path": input_s3_path.replace("batch_inputs", "batch_outputs") + ".out",
+            "output_s3_path": output_s3_path,
             "created_at": datetime.now().isoformat(),
         }
 
@@ -107,9 +116,14 @@ class LOMappingRequestDynamoDBRecord:
 
     def find_latest_awaiting_record_by_ids(self, course_id, program_id) -> dict | None:
         """Find the latest record for the given course/program awaiting post-processing"""
-        
+
         latest_record = None
         table = self._get_table()
+
+        # DynamoDB returns numeric attributes as Decimal but inputs may be int or str.
+        # Normalize both sides to str for comparison.
+        target_course_id  = str(course_id)
+        target_program_id = str(program_id)
 
         for status in ("AWAITING_COMPLETION", "AWAITING_COMPLETION_FAILED"):
             response = table.query(
@@ -118,7 +132,7 @@ class LOMappingRequestDynamoDBRecord:
             )
 
             for item in response.get("Items", []):
-                if item.get("course_id") != course_id or item.get("program_id") != program_id:
+                if str(item.get("course_id")) != target_course_id or str(item.get("program_id")) != target_program_id:
                     continue
                 if latest_record is None or item.get("created_at", "") > latest_record.get("created_at", ""):
                     latest_record = item
@@ -130,12 +144,64 @@ class LOMappingRequestDynamoDBRecord:
                     ExclusiveStartKey=response["LastEvaluatedKey"],
                 )
                 for item in response.get("Items", []):
-                    if item.get("course_id") != course_id or item.get("program_id") != program_id:
+                    if str(item.get("course_id")) != target_course_id or str(item.get("program_id")) != target_program_id:
                         continue
                     if latest_record is None or item.get("created_at", "") > latest_record.get("created_at", ""):
                         latest_record = item
 
         return latest_record
+
+    IN_FLIGHT_STATUSES = (
+        "PENDING",
+        "IN_PROGRESS",
+        "AWAITING_COMPLETION",
+        "AWAITING_COMPLETION_FAILED",
+    )
+
+    def find_in_flight_records_for_pairs(self, pairs: list[tuple]) -> dict:
+        """
+        Given a list of (course_id, program_id) tuples, return a dict mapping each
+        tuple to the latest in-flight DynamoDB record (or None if none exists).
+
+        "In-flight" means the record exists in any status that hasn't been delivered
+        to Laravel and deleted yet (PENDING, IN_PROGRESS, AWAITING_COMPLETION,
+        AWAITING_COMPLETION_FAILED).
+
+        Single GSI scan per status; in-memory filter for the requested pairs.
+        """
+        result = {pair: None for pair in pairs}
+        if not pairs:
+            return result
+
+        # Normalize to str so callers can pass int/str/Decimal interchangeably.
+        pair_set = {(str(c), str(p)) for c, p in pairs}
+        normalized_to_original = {(str(c), str(p)): (c, p) for c, p in pairs}
+        table = self._get_table()
+
+        for status in self.IN_FLIGHT_STATUSES:
+            args = {
+                "IndexName": self.status_index,
+                "KeyConditionExpression": Key("status").eq(status),
+            }
+            response = table.query(**args)
+            self._collect_matching(response.get("Items", []), pair_set, normalized_to_original, result)
+
+            while "LastEvaluatedKey" in response:
+                response = table.query(**args, ExclusiveStartKey=response["LastEvaluatedKey"])
+                self._collect_matching(response.get("Items", []), pair_set, normalized_to_original, result)
+
+        return result
+
+    @staticmethod
+    def _collect_matching(items: list[dict], pair_set: set, normalized_to_original: dict, result: dict) -> None:
+        for item in items:
+            normalized = (str(item.get("course_id")), str(item.get("program_id")))
+            if normalized not in pair_set:
+                continue
+            pair = normalized_to_original[normalized]
+            current = result.get(pair)
+            if current is None or item.get("created_at", "") > current.get("created_at", ""):
+                result[pair] = item
 
     def delete_request(self, request_id: str) -> None:
         """Delete a record by its request_id"""

--- a/python/services/lo_mapping_service/app/services/lo_mapping_request_dynamo_db_request.py
+++ b/python/services/lo_mapping_service/app/services/lo_mapping_request_dynamo_db_request.py
@@ -13,7 +13,7 @@ class LOMappingRequestDynamoDBRecord:
 
     def __init__(self, settings: Settings | None = None):
         self.settings = settings or Settings()
-        self.table_name = self.settings.LO_MAPPING_REQUESTS_TABLE
+        self.table_name = self.settings.LO_MAPPING_DYNAMODB_REQUESTS_TABLE
         self.aws_region = self.settings.AWS_REGION
         self.aws_access_key = self.settings.ACCESS_KEY
         self.aws_secret_key = self.settings.SECRET_KEY
@@ -21,7 +21,7 @@ class LOMappingRequestDynamoDBRecord:
 
     def ensure_table_exists(self):
         if not self.table_name:
-            raise ValueError("LO_MAPPING_REQUESTS_TABLE is not set")
+            raise ValueError("LO_MAPPING_DYNAMODB_REQUESTS_TABLE is not set")
 
         boto_session = self._create_boto_session()
         dynamodb = boto_session.resource("dynamodb", region_name=self.aws_region)
@@ -60,7 +60,7 @@ class LOMappingRequestDynamoDBRecord:
 
     def create_request(self, course_id, program_id, input_s3_path, status: str = "PENDING",):
         if not self.table_name:
-            raise ValueError("LO_MAPPING_REQUESTS_TABLE is not set")
+            raise ValueError("LO_MAPPING_DYNAMODB_REQUESTS_TABLE is not set")
         if not input_s3_path:
             raise ValueError("input_s3_path is required")
 
@@ -154,5 +154,5 @@ class LOMappingRequestDynamoDBRecord:
 
     def _get_table(self):
         if not self.table_name:
-            raise ValueError("LO_MAPPING_REQUESTS_TABLE is not set")
+            raise ValueError("LO_MAPPING_DYNAMODB_REQUESTS_TABLE is not set")
         return self._create_boto_session().resource("dynamodb").Table(self.table_name)

--- a/python/services/lo_mapping_service/app/services/process_batch_transform_results.py
+++ b/python/services/lo_mapping_service/app/services/process_batch_transform_results.py
@@ -7,10 +7,6 @@ from decimal import Decimal
 from pathlib import Path
 from dotenv import load_dotenv
 
-# Resolve .env from the service root (../../.env relative to this file) so it
-# works regardless of where uvicorn was launched from. override=False so explicit
-# env vars from the parent process (e.g. an E2E test launching this as a subprocess)
-# take precedence over .env defaults.
 _SERVICE_ROOT = Path(__file__).resolve().parents[2]
 load_dotenv(_SERVICE_ROOT / ".env", override=False)
 

--- a/python/services/lo_mapping_service/app/services/process_batch_transform_results.py
+++ b/python/services/lo_mapping_service/app/services/process_batch_transform_results.py
@@ -3,6 +3,16 @@ import httpx
 import json
 import os
 import re
+from decimal import Decimal
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Resolve .env from the service root (../../.env relative to this file) so it
+# works regardless of where uvicorn was launched from. override=True so a stale
+# value already in os.environ (e.g. inherited from the shell) gets replaced.
+_SERVICE_ROOT = Path(__file__).resolve().parents[2]
+load_dotenv(_SERVICE_ROOT / ".env", override=True)
+
 from app.core.logging_config import logger
 from app.services.lo_mapping_request_dynamo_db_request import LOMappingRequestDynamoDBRecord
 
@@ -19,6 +29,8 @@ boto_session = boto3.Session(
 s3       = boto_session.client("s3")
 
 LARAVEL_API_URL = os.getenv("LARAVEL_API_URL")
+print(f"[lo_mapping_service] LARAVEL_API_URL loaded as: {LARAVEL_API_URL!r} (from {_SERVICE_ROOT / '.env'})", flush=True)
+logger.info("LARAVEL_API_URL loaded as: %r (from %s)", LARAVEL_API_URL, _SERVICE_ROOT / ".env")
 lo_mapping_request_store = LOMappingRequestDynamoDBRecord()
 
 
@@ -196,12 +208,15 @@ def delete_dynamodb_record(record_id: str) -> None:
 
 async def send_results_to_external_api(record_id: str, results: list[dict], record: dict) -> None:
     """POST all extracted results for a single record to the external API"""
+    # DynamoDB returns numeric attributes as Decimal, which json doesn't handle.
+    course_id  = record.get("course_id")
+    program_id = record.get("program_id")
     payload = {
-        "request_id":      record_id,
-        "course_id":  record.get("course_id"),
-        "program_id": record.get("program_id"),
-        "status": record.get("status"),
-        "results":       results,   # list of {clo_id, plo_id, clo, accreditation_standard, explanation, map_labels, is_mapped}
+        "request_id": record_id,
+        "course_id":  int(course_id)  if isinstance(course_id, Decimal)  else course_id,
+        "program_id": int(program_id) if isinstance(program_id, Decimal) else program_id,
+        "status":     record.get("status"),
+        "results":    results,   # list of {clo_id, plo_id, clo, accreditation_standard, explanation, map_labels, is_mapped}
     }
 
     async with httpx.AsyncClient(timeout=30) as client:
@@ -213,7 +228,7 @@ async def send_results_to_external_api(record_id: str, results: list[dict], reco
         )
 
 
-async def process_records(records: list) -> None:
+async def process_records(records: list) -> dict:
     """
     For each record:
       - get the S3 output path from the DynamoDB record
@@ -222,9 +237,15 @@ async def process_records(records: list) -> None:
       - Send all results for this record to the external API
       - Delete the DynamoDB record
 
-    A failure in one record is logged but record is not deleted
+    A failure in one record is logged but record is not deleted.
+
+    Returns {"succeeded": [...], "failed": [...]} of request_ids so callers can
+    distinguish a successful delivery from a transient failure.
     """
     logger.info("Starting processing for %d record(s).", len(records))
+
+    succeeded: list[str] = []
+    failed:    list[str] = []
 
     for record in records:
         record_id = record.get("request_id")
@@ -239,15 +260,20 @@ async def process_records(records: list) -> None:
                 )
                 await send_results_to_external_api(record_id, [], record)
                 delete_dynamodb_record(record_id)
+                succeeded.append(record_id)
                 continue
 
             output_s3_uri = record.get("output_s3_path")
             if not output_s3_uri:
+                # Mirror what create_request now does: <OUTPUT_S3_URI>/<input_filename>.out
                 input_s3_path = record.get("input_s3_path", "")
-                output_s3_uri = input_s3_path.replace("batch_inputs", "batch_outputs") + ".out"
-                if not output_s3_uri:
-                    logger.warning("Record '%s' is missing output_s3_path — using '%s'.", record_id, output_s3_uri)
+                output_prefix = (os.getenv("OUTPUT_S3_URI") or "").rstrip("/")
+                input_filename = input_s3_path.rsplit("/", 1)[-1] if input_s3_path else ""
+                if not output_prefix or not input_filename:
+                    logger.warning("Record '%s' is missing output_s3_path and OUTPUT_S3_URI/input_s3_path can't fill it — skipping.", record_id)
+                    failed.append(record_id)
                     continue
+                output_s3_uri = f"{output_prefix}/{input_filename}.out"
 
             lines = read_s3_jsonl(output_s3_uri)
 
@@ -260,12 +286,15 @@ async def process_records(records: list) -> None:
             await send_results_to_external_api(record_id, results, record)
 
             delete_dynamodb_record(record_id)
+            succeeded.append(record_id)
 
         except Exception as e:
             logger.error(
                 "Failed to process record '%s': %s — skipping.",
                 record_id, e,
             )
+            failed.append(record_id)
             continue
 
-    logger.info("Finished processing %d record(s).", len(records))
+    logger.info("Finished processing %d record(s). Succeeded=%d Failed=%d", len(records), len(succeeded), len(failed))
+    return {"succeeded": succeeded, "failed": failed}

--- a/python/services/lo_mapping_service/app/services/process_batch_transform_results.py
+++ b/python/services/lo_mapping_service/app/services/process_batch_transform_results.py
@@ -8,10 +8,11 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 # Resolve .env from the service root (../../.env relative to this file) so it
-# works regardless of where uvicorn was launched from. override=True so a stale
-# value already in os.environ (e.g. inherited from the shell) gets replaced.
+# works regardless of where uvicorn was launched from. override=False so explicit
+# env vars from the parent process (e.g. an E2E test launching this as a subprocess)
+# take precedence over .env defaults.
 _SERVICE_ROOT = Path(__file__).resolve().parents[2]
-load_dotenv(_SERVICE_ROOT / ".env", override=True)
+load_dotenv(_SERVICE_ROOT / ".env", override=False)
 
 from app.core.logging_config import logger
 from app.services.lo_mapping_request_dynamo_db_request import LOMappingRequestDynamoDBRecord

--- a/python/services/lo_mapping_service/deploy/DEPLOY.md
+++ b/python/services/lo_mapping_service/deploy/DEPLOY.md
@@ -6,27 +6,36 @@ End-to-end PowerShell commands to deploy both Lambda functions for the lo_mappin
 
 ## Prerequisites
 
-- AWS CLI installed and configured (`aws configure`)
-- Your IAM user can run `aws lambda create-function`
-- The Lambda execution role exists and has Lambda + SageMaker as trusted services
-- The `.env` file at `python/services/lo_mapping_service/.env` is filled in with all required values
-- The `DYNAMODB_STATUS_INDEX` line in `.env` has no inline comment
+- AWS CLI installed and configure`d (`aws configure`).
+- Your IAM user has permissions for `lambda:CreateFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:GetFunction`, plus `events:PutRule`, `events:PutTargets`, and `lambda:AddPermission` if you are wiring EventBridge.
+- An IAM execution role exists for the Lambda. Its trust policy must allow **both** `lambda.amazonaws.com` (so Lambda can run as the role) and `sagemaker.amazonaws.com` (so SageMaker can be passed the same role for batch transform), and the role must have runtime permissions on DynamoDB, S3, SageMaker, CloudWatch Logs, and `lambda:InvokeFunction` on the second Lambda. The role ARN goes in your `.env` as `IAM_ROLE_ARN` (used both as the Lambda's own execution role and as the role passed to SageMaker).
+- The `.env` file for the service is filled in with all required values. Confirm there are no inline comments after any value (PowerShell's `.env` parser does not strip them by default).
+- A Lambda execution role ARN, which we refer to as `$ROLE_ARN` below. This may be the same as `IAM_ROLE_ARN` if a single role is used for both purposes.
 
-## 1. Set up PowerShell variables
+## 0. Set the project root
+
+Run all commands from the service root directory (`python/services/lo_mapping_service/`). All paths below are relative to that. Set `$ROOT` once at the start of your session:
+
+```powershell
+# Adjust if your working directory is different
+$ROOT     = (Get-Location).Path
+$DEPLOY   = "$ROOT\deploy"
+$HANDLERS = "$ROOT\app\lambda_handlers"
+```
+
+## 1. Load env vars and set PowerShell variables
 
 ```powershell
 # Load all .env values into the current PowerShell session
-$ENV_FILE = "e:\Forestry\MAP\curriculum-development-tool\python\services\lo_mapping_service\.env"
+$ENV_FILE = "$ROOT\.env"
 Get-Content $ENV_FILE | ForEach-Object {
     if ($_ -match '^\s*([^#][^=]+)=([^#]*)') {
         [System.Environment]::SetEnvironmentVariable($matches[1].Trim(), $matches[2].Trim())
     }
 }
 
-# Hardcoded paths and the Lambda execution role ARN
-$ROLE_ARN = "arn:aws:iam::368677659554:role/service-role/SageMaker-SmallTLEFDeveloper"
-$DEPLOY   = "e:\Forestry\MAP\curriculum-development-tool\python\services\lo_mapping_service\deploy"
-$HANDLERS = "e:\Forestry\MAP\curriculum-development-tool\python\services\lo_mapping_service\app\lambda_handlers"
+# Lambda execution role ARN. Keep this out of .env unless you also want it for runtime use.
+$ROLE_ARN = "<paste-the-lambda-execution-role-arn-here>"
 
 # Pull values out of env into PowerShell variables for easy reference
 $REGION         = $env:AWS_REGION
@@ -50,7 +59,7 @@ Write-Host "SAGEMAKER_ROLE: $SAGEMAKER_ROLE"
 Write-Host "ROLE_ARN:       $ROLE_ARN"
 ```
 
-If any are blank, that value is missing from `.env`.
+If any are blank, that value is missing from `.env` (or `$ROLE_ARN` was not set).
 
 ## 2. Zip both Lambda handlers
 
@@ -77,7 +86,7 @@ $json = [PSCustomObject]@{
         HF_IMAGE_URI                       = $HF_IMAGE_URI
         HF_TASK                            = "text-generation"
         INSTANCE_TYPE                      = "ml.g5.2xlarge"
- t       INSTANCE_COUNT                     = "1"
+        INSTANCE_COUNT                     = "1"
         OUTPUT_S3_URI                      = $OUTPUT_S3_URI
         JOB_NAME_PREFIX                    = "hf-batch-transform"
         MODEL_NAME_PREFIX                  = "hf-batch-transform-model"
@@ -112,7 +121,8 @@ $json = [PSCustomObject]@{
         DYNAMODB_TABLE        = $TABLE_NAME
         START_JOB_LAMBDA_NAME = "start-batch-transform-job"
         STATUS_INDEX          = $STATUS_INDEX
-        JOB_NAME_PREFIX       = "hf-batch-transform"}
+        JOB_NAME_PREFIX       = "hf-batch-transform"
+    }
 } | ConvertTo-Json -Depth 3 -Compress
 
 [System.IO.File]::WriteAllText($tmpFile, $json, (New-Object System.Text.UTF8Encoding $false))
@@ -137,15 +147,18 @@ aws lambda get-function --function-name start-batch-transform-job --region $REGI
 aws lambda get-function --function-name process-batch-transform-results --region $REGION
 ```
 
-Both should return JSON with `Configuration` blocks. If you see them, the Lambdas are deployed.
+Both should return JSON with `Configuration` blocks.
 
 ## 6. Wire EventBridge to invoke `process-batch-transform-results`
 
-The second Lambda is meant to be triggered by EventBridge when SageMaker batch transform jobs change state. Create the EventBridge rule:
+The second Lambda is triggered by EventBridge when SageMaker batch transform jobs change state. Create the EventBridge rule:
 
 ```powershell
-# Create the rule. PowerShell strips inner double quotes when passing string vars to
-# native executables, so we write the pattern to a temp file and use file:// instead.
+# Pull your AWS account ID from STS so we don't hardcode it
+$ACCOUNT_ID = (aws sts get-caller-identity --query Account --output text)
+
+# PowerShell strips inner double quotes when passing string vars to native executables,
+# so we write the pattern to a temp file and use file:// instead.
 $tmpPattern = [System.IO.Path]::GetTempFileName()
 $pattern = '{"source":["aws.sagemaker"],"detail-type":["SageMaker Transform Job State Change"]}'
 [System.IO.File]::WriteAllText($tmpPattern, $pattern, (New-Object System.Text.UTF8Encoding $false))
@@ -160,7 +173,7 @@ Remove-Item $tmpPattern
 # Get the Lambda ARN
 $LAMBDA_ARN = (aws lambda get-function --function-name process-batch-transform-results --region $REGION --query 'Configuration.FunctionArn' --output text)
 
-# Add the Lambda as a target
+# Add the Lambda as a target of the rule
 aws events put-targets `
   --rule sagemaker-transform-job-state-change `
   --targets "Id=1,Arn=$LAMBDA_ARN" `
@@ -172,31 +185,81 @@ aws lambda add-permission `
   --statement-id eventbridge-invoke `
   --action lambda:InvokeFunction `
   --principal events.amazonaws.com `
-  --source-arn "arn:aws:events:${REGION}:368677659554:rule/sagemaker-transform-job-state-change" `
+  --source-arn "arn:aws:events:${REGION}:${ACCOUNT_ID}:rule/sagemaker-transform-job-state-change" `
   --region $REGION
 ```
 
 ## Re-deploys
 
-If you need to update an existing Lambda's code or env vars, use `update-function-code` and `update-function-configuration` instead of `create-function`:
+If you need to update an existing Lambda's code or env vars, use `update-function-code` and `update-function-configuration` instead of `create-function`. Do NOT use `create-function`, it will fail because the function already exists.
 
 ```powershell
-# Update code
+# Update code only (no env var change)
+Compress-Archive -Path "$HANDLERS\lambda_handler_start_batch_tranform_job.py" `
+  -DestinationPath "$DEPLOY\start-batch-transform-job.zip" -Force
+
 aws lambda update-function-code `
   --function-name start-batch-transform-job `
   --zip-file fileb://$DEPLOY\start-batch-transform-job.zip `
   --region $REGION
 
-# Update env vars (rebuild $tmpFile first as in step 3)
+# Update env vars only (re-build $tmpFile first as in step 3 or 4)
 aws lambda update-function-configuration `
   --function-name start-batch-transform-job `
   --environment file://$tmpFile `
   --region $REGION
 ```
 
+### Verify the deploy actually took effect
+
+It is easy to get a "success" exit code from the Compress-Archive + update-function-code chain even when the deployed code is not what you expect (for example, if `$HANDLERS` was not set in the current shell). Always confirm with:
+
+```powershell
+aws lambda get-function `
+  --function-name <FUNCTION_NAME> `
+  --region $REGION `
+  --query "Configuration.LastModified"
+```
+
+`LastModified` should match the time you ran the update (within a few seconds). If it shows an older timestamp, the deploy did not actually go through.
+
+You can also invoke the Lambda directly with a synthetic test event to confirm logic changes are in effect:
+
+```powershell
+$tmpEvent = [System.IO.Path]::GetTempFileName()
+'{"detail":{"TransformJobName":"test-fake-job","TransformJobStatus":"InProgress"}}' |
+  Out-File -FilePath $tmpEvent -Encoding ascii -NoNewline
+
+aws lambda invoke `
+  --function-name process-batch-transform-results `
+  --payload file://$tmpEvent `
+  --cli-binary-format raw-in-base64-out `
+  --region $REGION `
+  response.json
+
+Get-Content response.json
+Remove-Item $tmpEvent, response.json
+```
+
+For the `process-batch-transform-results` Lambda invoked with `InProgress`, you should see `"Non-terminal state 'InProgress' - no action taken."` if the terminal-state filter is in effect.
+
 ## Troubleshooting
 
-- **`The role defined for the function cannot be assumed by Lambda.`** The role's trust policy does not include `lambda.amazonaws.com`. Admin needs to add it.
-- **`Expected: '=', received: ''` on `--environment`.** The temp JSON file has a UTF-8 BOM. Make sure you used `[System.IO.File]::WriteAllText` with `(New-Object System.Text.UTF8Encoding $false)`, not `Out-File`.
+- **`The role defined for the function cannot be assumed by Lambda.`** The role's trust policy does not include `lambda.amazonaws.com`. Update the trust policy to add it (or ask the admin).
+- **`ValidationException ... Could not assume role ... for principal sagemaker.amazonaws.com`** when SageMaker tries to use the role you passed in `IAM_ROLE_ARN`. Either the role's trust policy does not include `sagemaker.amazonaws.com`, or your Lambda's role does not have `iam:PassRole` on the SageMaker role. Easiest fix is to use one role that lists both `lambda` and `sagemaker` as trusted principals (then Lambda is "passing itself", which is always allowed).
+- **`Cannot create already existing model "..."`** in CloudWatch for `start-batch-transform-job`. The handler should be idempotent. Replace `create_model()` with a `describe_model` check first, then `create_model` only if not found.
+- **`AttributeError: 'decimal.Decimal' object has no attribute 'strip'`** in CloudWatch. DynamoDB returns numeric attributes as `Decimal`. Cast `course_id` and `program_id` to `str()` before passing to functions that call `.strip()` or regex on them.
+- **EventBridge Lambda flips records to `AWAITING_COMPLETION_FAILED` mid-job.** SageMaker emits state-change events for non-terminal states like `InProgress`. The Lambda must filter for terminal states (`Completed`, `Failed`, `Stopped`) and ignore others.
+- **`Expected: '=', received: ''` on `--environment` or `--key`.** PowerShell 5.1 strips inner `"` when passing string args to native executables, and `Out-File -Encoding utf8` adds a UTF-8 BOM that AWS CLI rejects. Always write JSON to a temp file using `[System.IO.File]::WriteAllText($tmpFile, $json, (New-Object System.Text.UTF8Encoding $false))` and pass via `file://$tmpFile`.
 - **`Function not found`** when FastAPI tries to invoke the Lambda. The Lambda was not deployed, or the name in `routes.py` does not match the deployed function name (`start-batch-transform-job`).
-- **`AccessDeniedException`** at runtime. The Lambda execution role is missing the runtime permission for whichever AWS service it failed on (DynamoDB, S3, SageMaker, etc.). Admin needs to add it.
+- **`AccessDeniedException`** at runtime. The Lambda execution role is missing the runtime permission for whichever AWS service it failed on (DynamoDB, S3, SageMaker, etc.). Admin needs to add the missing action.
+
+## Required code prerequisites in the Lambda handlers
+
+Before you deploy, the handler files in `app/lambda_handlers/` must include the following fixes:
+
+- **`lambda_handler_start_batch_tranform_job.py`**
+  - In `build_job_name`, cast `course_id` and `program_id` to `str()` before passing them to `_is_known` / `_sanitize_for_job_name` (DynamoDB returns them as `Decimal`).
+  - In `create_model`, call `sm.describe_model` first; only create if it does not already exist. Otherwise repeated invocations fail because the model name is fixed.
+- **`lambda_handler_process_batch_transform_inference_results.py`**
+  - At the top of `lambda_handler`, filter for terminal `TransformJobStatus` values (`Completed`, `Failed`, `Stopped`). Return early on anything else, otherwise the Lambda mishandles `InProgress` events as failures.

--- a/python/services/lo_mapping_service/deploy/DEPLOY.md
+++ b/python/services/lo_mapping_service/deploy/DEPLOY.md
@@ -1,0 +1,202 @@
+# Note: this documentation was compiled by an AI Tool
+
+# Lambda Deployment Guide
+
+End-to-end PowerShell commands to deploy both Lambda functions for the lo_mapping_service.
+
+## Prerequisites
+
+- AWS CLI installed and configured (`aws configure`)
+- Your IAM user can run `aws lambda create-function`
+- The Lambda execution role exists and has Lambda + SageMaker as trusted services
+- The `.env` file at `python/services/lo_mapping_service/.env` is filled in with all required values
+- The `DYNAMODB_STATUS_INDEX` line in `.env` has no inline comment
+
+## 1. Set up PowerShell variables
+
+```powershell
+# Load all .env values into the current PowerShell session
+$ENV_FILE = "e:\Forestry\MAP\curriculum-development-tool\python\services\lo_mapping_service\.env"
+Get-Content $ENV_FILE | ForEach-Object {
+    if ($_ -match '^\s*([^#][^=]+)=([^#]*)') {
+        [System.Environment]::SetEnvironmentVariable($matches[1].Trim(), $matches[2].Trim())
+    }
+}
+
+# Hardcoded paths and the Lambda execution role ARN
+$ROLE_ARN = "arn:aws:iam::368677659554:role/service-role/SageMaker-SmallTLEFDeveloper"
+$DEPLOY   = "e:\Forestry\MAP\curriculum-development-tool\python\services\lo_mapping_service\deploy"
+$HANDLERS = "e:\Forestry\MAP\curriculum-development-tool\python\services\lo_mapping_service\app\lambda_handlers"
+
+# Pull values out of env into PowerShell variables for easy reference
+$REGION         = $env:AWS_REGION
+$ACCESS_KEY     = $env:ACCESS_KEY
+$SECRET_KEY     = $env:SECRET_KEY
+$TABLE_NAME     = $env:LO_MAPPING_DYNAMODB_REQUESTS_TABLE
+$STATUS_INDEX   = $env:DYNAMODB_STATUS_INDEX
+$HF_MODEL_ID    = $env:HF_MODEL_ID
+$HF_IMAGE_URI   = $env:HF_IMAGE_URI
+$OUTPUT_S3_URI  = $env:OUTPUT_S3_URI
+$SAGEMAKER_ROLE = $env:IAM_ROLE_ARN
+```
+
+Verify the values loaded:
+
+```powershell
+Write-Host "REGION:         $REGION"
+Write-Host "TABLE_NAME:     $TABLE_NAME"
+Write-Host "HF_MODEL_ID:    $HF_MODEL_ID"
+Write-Host "SAGEMAKER_ROLE: $SAGEMAKER_ROLE"
+Write-Host "ROLE_ARN:       $ROLE_ARN"
+```
+
+If any are blank, that value is missing from `.env`.
+
+## 2. Zip both Lambda handlers
+
+```powershell
+Compress-Archive -Path "$HANDLERS\lambda_handler_start_batch_tranform_job.py" `
+  -DestinationPath "$DEPLOY\start-batch-transform-job.zip" -Force
+
+Compress-Archive -Path "$HANDLERS\lambda_handler_process_batch_transform_inference_results.py" `
+  -DestinationPath "$DEPLOY\process-batch-transform-results.zip" -Force
+```
+
+## 3. Deploy `start-batch-transform-job` Lambda
+
+Build the env JSON in memory, write to a temp file (NOT the project), deploy, delete:
+
+```powershell
+$tmpFile = [System.IO.Path]::GetTempFileName()
+$json = [PSCustomObject]@{
+    Variables = [PSCustomObject]@{
+        ACCESS_KEY                         = $ACCESS_KEY
+        SECRET_KEY                         = $SECRET_KEY
+        IAM_ROLE_ARN                       = $SAGEMAKER_ROLE
+        HF_MODEL_ID                        = $HF_MODEL_ID
+        HF_IMAGE_URI                       = $HF_IMAGE_URI
+        HF_TASK                            = "text-generation"
+        INSTANCE_TYPE                      = "ml.g5.2xlarge"
+ t       INSTANCE_COUNT                     = "1"
+        OUTPUT_S3_URI                      = $OUTPUT_S3_URI
+        JOB_NAME_PREFIX                    = "hf-batch-transform"
+        MODEL_NAME_PREFIX                  = "hf-batch-transform-model"
+        LO_MAPPING_DYNAMODB_REQUESTS_TABLE = $TABLE_NAME
+        DYNAMODB_STATUS_INDEX              = $STATUS_INDEX
+    }
+} | ConvertTo-Json -Depth 3 -Compress
+
+[System.IO.File]::WriteAllText($tmpFile, $json, (New-Object System.Text.UTF8Encoding $false))
+
+aws lambda create-function `
+  --function-name start-batch-transform-job `
+  --runtime python3.12 `
+  --role $ROLE_ARN `
+  --handler lambda_handler_start_batch_tranform_job.lambda_handler `
+  --zip-file fileb://$DEPLOY\start-batch-transform-job.zip `
+  --region $REGION `
+  --timeout 300 `
+  --environment file://$tmpFile
+
+Remove-Item $tmpFile
+```
+
+## 4. Deploy `process-batch-transform-results` Lambda
+
+```powershell
+$tmpFile = [System.IO.Path]::GetTempFileName()
+$json = [PSCustomObject]@{
+    Variables = [PSCustomObject]@{
+        ACCESS_KEY            = $ACCESS_KEY
+        SECRET_KEY            = $SECRET_KEY
+        DYNAMODB_TABLE        = $TABLE_NAME
+        START_JOB_LAMBDA_NAME = "start-batch-transform-job"
+        STATUS_INDEX          = $STATUS_INDEX
+        JOB_NAME_PREFIX       = "hf-batch-transform"}
+} | ConvertTo-Json -Depth 3 -Compress
+
+[System.IO.File]::WriteAllText($tmpFile, $json, (New-Object System.Text.UTF8Encoding $false))
+
+aws lambda create-function `
+  --function-name process-batch-transform-results `
+  --runtime python3.12 `
+  --role $ROLE_ARN `
+  --handler lambda_handler_process_batch_transform_inference_results.lambda_handler `
+  --zip-file fileb://$DEPLOY\process-batch-transform-results.zip `
+  --region $REGION `
+  --timeout 300 `
+  --environment file://$tmpFile
+
+Remove-Item $tmpFile
+```
+
+## 5. Verify both Lambdas exist
+
+```powershell
+aws lambda get-function --function-name start-batch-transform-job --region $REGION
+aws lambda get-function --function-name process-batch-transform-results --region $REGION
+```
+
+Both should return JSON with `Configuration` blocks. If you see them, the Lambdas are deployed.
+
+## 6. Wire EventBridge to invoke `process-batch-transform-results`
+
+The second Lambda is meant to be triggered by EventBridge when SageMaker batch transform jobs change state. Create the EventBridge rule:
+
+```powershell
+# Create the rule. PowerShell strips inner double quotes when passing string vars to
+# native executables, so we write the pattern to a temp file and use file:// instead.
+$tmpPattern = [System.IO.Path]::GetTempFileName()
+$pattern = '{"source":["aws.sagemaker"],"detail-type":["SageMaker Transform Job State Change"]}'
+[System.IO.File]::WriteAllText($tmpPattern, $pattern, (New-Object System.Text.UTF8Encoding $false))
+
+aws events put-rule `
+  --name sagemaker-transform-job-state-change `
+  --event-pattern file://$tmpPattern `
+  --region $REGION
+
+Remove-Item $tmpPattern
+
+# Get the Lambda ARN
+$LAMBDA_ARN = (aws lambda get-function --function-name process-batch-transform-results --region $REGION --query 'Configuration.FunctionArn' --output text)
+
+# Add the Lambda as a target
+aws events put-targets `
+  --rule sagemaker-transform-job-state-change `
+  --targets "Id=1,Arn=$LAMBDA_ARN" `
+  --region $REGION
+
+# Allow EventBridge to invoke the Lambda
+aws lambda add-permission `
+  --function-name process-batch-transform-results `
+  --statement-id eventbridge-invoke `
+  --action lambda:InvokeFunction `
+  --principal events.amazonaws.com `
+  --source-arn "arn:aws:events:${REGION}:368677659554:rule/sagemaker-transform-job-state-change" `
+  --region $REGION
+```
+
+## Re-deploys
+
+If you need to update an existing Lambda's code or env vars, use `update-function-code` and `update-function-configuration` instead of `create-function`:
+
+```powershell
+# Update code
+aws lambda update-function-code `
+  --function-name start-batch-transform-job `
+  --zip-file fileb://$DEPLOY\start-batch-transform-job.zip `
+  --region $REGION
+
+# Update env vars (rebuild $tmpFile first as in step 3)
+aws lambda update-function-configuration `
+  --function-name start-batch-transform-job `
+  --environment file://$tmpFile `
+  --region $REGION
+```
+
+## Troubleshooting
+
+- **`The role defined for the function cannot be assumed by Lambda.`** The role's trust policy does not include `lambda.amazonaws.com`. Admin needs to add it.
+- **`Expected: '=', received: ''` on `--environment`.** The temp JSON file has a UTF-8 BOM. Make sure you used `[System.IO.File]::WriteAllText` with `(New-Object System.Text.UTF8Encoding $false)`, not `Out-File`.
+- **`Function not found`** when FastAPI tries to invoke the Lambda. The Lambda was not deployed, or the name in `routes.py` does not match the deployed function name (`start-batch-transform-job`).
+- **`AccessDeniedException`** at runtime. The Lambda execution role is missing the runtime permission for whichever AWS service it failed on (DynamoDB, S3, SageMaker, etc.). Admin needs to add it.

--- a/python/services/lo_mapping_service/deploy/DEPLOY.md
+++ b/python/services/lo_mapping_service/deploy/DEPLOY.md
@@ -189,6 +189,20 @@ aws lambda add-permission `
   --region $REGION
 ```
 
+## Dev cleanup script
+
+For wiping transient test state on AWS (running SageMaker jobs, DynamoDB records, optionally S3 folders) without touching infra:
+
+```powershell
+# Stop in-flight transform jobs and delete every DynamoDB record
+.\deploy\cleanup-dev.ps1
+
+# Same, plus also empty the S3 batch_inputs/, batch_outputs/, output/ prefixes
+.\deploy\cleanup-dev.ps1 -ClearS3
+```
+
+It does NOT delete the EventBridge rule, the SageMaker model, or any Laravel data. See [deploy/cleanup-dev.ps1](deploy/cleanup-dev.ps1) for the exact behavior.
+
 ## Re-deploys
 
 If you need to update an existing Lambda's code or env vars, use `update-function-code` and `update-function-configuration` instead of `create-function`. Do NOT use `create-function`, it will fail because the function already exists.

--- a/python/services/lo_mapping_service/deploy/lambda-permissions-policy.json
+++ b/python/services/lo_mapping_service/deploy/lambda-permissions-policy.json
@@ -1,0 +1,54 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Sid": "DynamoDB",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:Query",
+        "dynamodb:DescribeTable"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:ca-central-1:368677659554:table/lo-mapping-requests",
+        "arn:aws:dynamodb:ca-central-1:368677659554:table/lo-mapping-requests/index/*"
+      ]
+    },
+    {
+      "Sid": "SageMaker",
+      "Effect": "Allow",
+      "Action": [
+        "sagemaker:CreateModel",
+        "sagemaker:CreateTransformJob",
+        "sagemaker:ListTransformJobs",
+        "sagemaker:DescribeTransformJob"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PassSageMakerRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::368677659554:role/AmazonSageMaker-ExecutionRole-20260120T160168"
+    },
+    {
+      "Sid": "InvokeNextLambda",
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:ca-central-1:368677659554:function:process-batch-transform-results"
+    }
+  ]
+}

--- a/python/services/lo_mapping_service/deploy/start-job-env.json
+++ b/python/services/lo_mapping_service/deploy/start-job-env.json
@@ -1,0 +1,17 @@
+{
+  "Variables": {
+    "ACCESS_KEY": "REPLACE_ME",
+    "SECRET_KEY": "REPLACE_ME",
+    "IAM_ROLE_ARN": "arn:aws:iam::368677659554:role/AmazonSageMaker-ExecutionRole-20260120T160168",
+    "HF_MODEL_ID": "Qwen/Qwen3-8B",
+    "HF_IMAGE_URI": "763104351884.dkr.ecr.ca-central-1.amazonaws.com/huggingface-pytorch-tgi-inference:2.7.0-tgi3.3.6-gpu-py311-cu124-ubuntu22.04",
+    "HF_TASK": "text-generation",
+    "INSTANCE_TYPE": "ml.g5.2xlarge",
+    "INSTANCE_COUNT": "1",
+    "OUTPUT_S3_URI": "s3://curriculum-map-testing-bucket/output/",
+    "JOB_NAME_PREFIX": "hf-batch-transform",
+    "MODEL_NAME_PREFIX": "hf-batch-transform-model",
+    "LO_MAPPING_DYNAMODB_REQUESTS_TABLE": "lo-mapping-requests",
+    "DYNAMODB_STATUS_INDEX": "status-created_at-index"
+  }
+}

--- a/python/services/lo_mapping_service/deploy/trust-policy.json
+++ b/python/services/lo_mapping_service/deploy/trust-policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/python/services/lo_mapping_service/requirements.txt
+++ b/python/services/lo_mapping_service/requirements.txt
@@ -7,7 +7,6 @@ aws-sam-translator==1.103.0
 aws-xray-sdk==2.15.0
 boto3==1.42.80
 botocore==1.42.80
-sagemaker>=2.200.0,<3.0.0
 certifi==2026.2.25
 cffi==2.0.0
 cfn-lint==1.41.0

--- a/python/services/lo_mapping_service/requirements.txt
+++ b/python/services/lo_mapping_service/requirements.txt
@@ -1,3 +1,4 @@
+APScheduler==3.10.4
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.13.0
@@ -6,6 +7,7 @@ aws-sam-translator==1.103.0
 aws-xray-sdk==2.15.0
 boto3==1.42.80
 botocore==1.42.80
+sagemaker>=2.200.0,<3.0.0
 certifi==2026.2.25
 cffi==2.0.0
 cfn-lint==1.41.0

--- a/python/services/lo_mapping_service/tests/e2e/README.md
+++ b/python/services/lo_mapping_service/tests/e2e/README.md
@@ -35,13 +35,11 @@ E2E_TEST_USER_EMAIL=<email>
 E2E_TEST_USER_PASSWORD=<password>
 ```
 
-If these are unset and stdin is a TTY, pytest prompts for them at the start of the session. Run pytest with `-s` to keep stdin connected for the prompt:
+If these are unset, pytest prompts for them at the start of the session. Run pytest with `-s` to keep stdin connected for the prompt:
 
 ```powershell
 pytest tests/e2e -v -s
 ```
-
-If stdin is not a TTY (e.g. CI), tests skip with a clear message.
 
 ## Run
 

--- a/python/services/lo_mapping_service/tests/e2e/README.md
+++ b/python/services/lo_mapping_service/tests/e2e/README.md
@@ -1,0 +1,71 @@
+# Note: this documentation was compiled by an AI Tool
+
+# E2E Tests for the AI Suggestion Pipeline
+
+- **LocalStack DynamoDB + S3** read/write by FastAPI
+- **FastAPI** `process_records` pipeline (S3 read, parse, deliver to Laravel)
+- **Laravel** `storeAiSuggestions` controller (writes rows, flips `manual_map_status` and `ai_suggestion_status`)
+- **Postgres** `outcome_map_ai_suggestions` rows
+- **Step 5 HTML** rendering (purple icons in the right cells)
+
+## Prerequisites
+
+Each of these must be running before invoking pytest:
+
+| Service | How to start | Default URL/DSN |
+|---|---|---|
+| Docker | OS-dependent | for LocalStack via testcontainers |
+| Postgres | OS-dependent | `postgresql://root@localhost:5432/laravel` |
+| Laravel | `php artisan serve` from `laravel/` | `http://127.0.0.1:8000` |
+
+**Important: stop your dev FastAPI before running tests.** The test fixture spawns its own FastAPI subprocess on port 8002 with LocalStack-pointing env vars. If a dev FastAPI is already on that port, the test fails fast with a clear message. Override the test port with `E2E_FASTAPI_PORT` if needed.
+
+You can override URLs and the Postgres DSN via env vars:
+```
+LARAVEL_URL          (default http://127.0.0.1:8000)
+E2E_FASTAPI_PORT     (default 8002 - port the test FastAPI binds to)
+E2E_PG_DSN           (default postgresql://root@localhost:5432/laravel)
+E2E_DYNAMO_TABLE     (default lo-mapping-requests-e2e)
+E2E_S3_BUCKET        (default curriculum-map-e2e-bucket)
+```
+
+You also need a Laravel test user account for authentication. Set:
+```
+E2E_TEST_USER_EMAIL=<email>
+E2E_TEST_USER_PASSWORD=<password>
+```
+
+If these are unset and stdin is a TTY, pytest prompts for them at the start of the session. Run pytest with `-s` to keep stdin connected for the prompt:
+
+```powershell
+pytest tests/e2e -v -s
+```
+
+If stdin is not a TTY (e.g. CI), tests skip with a clear message.
+
+## Run
+
+```powershell
+cd python/services/lo_mapping_service
+pip install -r tests/e2e/requirements.txt
+pytest tests/e2e -v
+```
+
+The first run takes a while because testcontainers pulls the LocalStack Docker image.
+
+## Test data
+
+A high-ID-range test course/program is created and torn down per test. IDs used:
+- `course_id = 99001`
+- `program_id = 99001`
+- `l_outcome_id` 99001-99002
+- `pl_outcome_id` 99001-99002
+- `map_scale_id` 99001-99002
+
+If a previous run failed mid-test, run the cleanup script:
+
+```powershell
+python tests/e2e/cleanup.py
+```
+
+It deletes the high-ID test rows (99001) in dependency order. The script is idempotent — safe to run anytime.

--- a/python/services/lo_mapping_service/tests/e2e/README.md
+++ b/python/services/lo_mapping_service/tests/e2e/README.md
@@ -51,6 +51,10 @@ pytest tests/e2e -v
 
 The first run takes a while because testcontainers pulls the LocalStack Docker image.
 
+## Test isolation (E2E vs unit tests)
+
+Unit tests under `tests/test_*.py` use `moto` (`@mock_aws`); these E2E tests use LocalStack. To keep the two from clashing in a single pytest session, E2E fixtures route boto3 to LocalStack by passing `endpoint_url=` explicitly on every client/resource, and by injecting `AWS_ENDPOINT_URL` into the FastAPI subprocess via its own env dict. Do not set `AWS_ENDPOINT_URL` on the host `os.environ` — moto only intercepts the standard AWS URLs, so a leaked LocalStack endpoint would silently redirect unit-test boto3 calls at LocalStack.
+
 ## Test data
 
 A high-ID-range test course/program is created and torn down per test. IDs used:

--- a/python/services/lo_mapping_service/tests/e2e/cleanup.py
+++ b/python/services/lo_mapping_service/tests/e2e/cleanup.py
@@ -22,15 +22,15 @@ import psycopg2
 PG_DSN = os.environ.get("E2E_PG_DSN", "postgresql://root@localhost:5432/laravel")
 
 CLEANUP_STATEMENTS = [
-    "DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id BETWEEN 99001 AND 99002",
-    "DELETE FROM outcome_maps                WHERE l_outcome_id BETWEEN 99001 AND 99002",
+    "DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id BETWEEN 99001 AND 99099",
+    "DELETE FROM outcome_maps                WHERE l_outcome_id BETWEEN 99001 AND 99099",
     "DELETE FROM course_users                WHERE course_id = 99001",
     "DELETE FROM program_users               WHERE program_id = 99001",
     "DELETE FROM course_programs             WHERE course_id = 99001 AND program_id = 99001",
     "DELETE FROM mapping_scale_programs      WHERE program_id = 99001",
-    "DELETE FROM program_learning_outcomes   WHERE pl_outcome_id BETWEEN 99001 AND 99002",
-    "DELETE FROM learning_outcomes           WHERE l_outcome_id BETWEEN 99001 AND 99002",
-    "DELETE FROM mapping_scales              WHERE map_scale_id BETWEEN 99001 AND 99002",
+    "DELETE FROM program_learning_outcomes   WHERE pl_outcome_id BETWEEN 99001 AND 99099",
+    "DELETE FROM learning_outcomes           WHERE l_outcome_id BETWEEN 99001 AND 99099",
+    "DELETE FROM mapping_scales              WHERE map_scale_id BETWEEN 99001 AND 99099",
     "DELETE FROM programs                    WHERE program_id = 99001",
     "DELETE FROM courses                     WHERE course_id = 99001",
 ]

--- a/python/services/lo_mapping_service/tests/e2e/cleanup.py
+++ b/python/services/lo_mapping_service/tests/e2e/cleanup.py
@@ -1,16 +1,20 @@
 """
-Standalone cleanup for E2E test data in Postgres.
+Standalone cleanup for E2E test state after a mid-test crash
 
-Run after a mid-test crash to wipe the high-ID rows the seeded_course_program
-fixture would normally tear down. LocalStack/DynamoDB/S3 cleanup is not needed
-because those go away with the LocalStack container.
+Postgres: wipes the high-ID rows the seeded_course_program fixture would have created
+
+Docker: with --docker, force-removes any testcontainers-labelled LocalStack container 
+left behind by a crashed pytest session
 
 Usage:
     python tests/e2e/cleanup.py
+    python tests/e2e/cleanup.py --docker
 
 Honours E2E_PG_DSN env var (default: postgresql://root@localhost:5432/laravel).
 """
+import argparse
 import os
+import subprocess
 import sys
 
 import psycopg2
@@ -20,6 +24,8 @@ PG_DSN = os.environ.get("E2E_PG_DSN", "postgresql://root@localhost:5432/laravel"
 CLEANUP_STATEMENTS = [
     "DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id BETWEEN 99001 AND 99002",
     "DELETE FROM outcome_maps                WHERE l_outcome_id BETWEEN 99001 AND 99002",
+    "DELETE FROM course_users                WHERE course_id = 99001",
+    "DELETE FROM program_users               WHERE program_id = 99001",
     "DELETE FROM course_programs             WHERE course_id = 99001 AND program_id = 99001",
     "DELETE FROM mapping_scale_programs      WHERE program_id = 99001",
     "DELETE FROM program_learning_outcomes   WHERE pl_outcome_id BETWEEN 99001 AND 99002",
@@ -30,7 +36,7 @@ CLEANUP_STATEMENTS = [
 ]
 
 
-def main() -> int:
+def cleanup_postgres() -> int:
     print(f"Connecting to {PG_DSN} ...")
     try:
         conn = psycopg2.connect(PG_DSN)
@@ -57,6 +63,51 @@ def main() -> int:
 
     print(f"\nDone. {total} row(s) deleted.")
     return 0
+
+
+def cleanup_docker() -> int:
+    """Force-remove testcontainers-labelled LocalStack containers from crashed runs."""
+    print("\nLooking for leftover testcontainers LocalStack containers ...")
+    try:
+        result = subprocess.run(
+            [
+                "docker", "ps", "-aq",
+                "--filter", "label=org.testcontainers=true",
+                "--filter", "ancestor=localstack/localstack:3.0",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+    except FileNotFoundError:
+        print("  docker CLI not found; skipping.", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as e:
+        print(f"  docker ps failed: {e.stderr.strip()}", file=sys.stderr)
+        return 1
+
+    ids = [cid for cid in result.stdout.split() if cid]
+    if not ids:
+        print("  None found.")
+        return 0
+
+    print(f"  Removing {len(ids)} container(s): {' '.join(ids)}")
+    try:
+        subprocess.run(["docker", "rm", "-f", *ids], check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"  docker rm failed: {e.stderr.strip()}", file=sys.stderr)
+        return 1
+    print("  Done.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--docker", action="store_true", help="also force-remove leftover LocalStack containers")
+    args = parser.parse_args()
+
+    rc = cleanup_postgres()
+    if args.docker:
+        rc = cleanup_docker() or rc
+    return rc
 
 
 if __name__ == "__main__":

--- a/python/services/lo_mapping_service/tests/e2e/cleanup.py
+++ b/python/services/lo_mapping_service/tests/e2e/cleanup.py
@@ -1,0 +1,63 @@
+"""
+Standalone cleanup for E2E test data in Postgres.
+
+Run after a mid-test crash to wipe the high-ID rows the seeded_course_program
+fixture would normally tear down. LocalStack/DynamoDB/S3 cleanup is not needed
+because those go away with the LocalStack container.
+
+Usage:
+    python tests/e2e/cleanup.py
+
+Honours E2E_PG_DSN env var (default: postgresql://root@localhost:5432/laravel).
+"""
+import os
+import sys
+
+import psycopg2
+
+PG_DSN = os.environ.get("E2E_PG_DSN", "postgresql://root@localhost:5432/laravel")
+
+CLEANUP_STATEMENTS = [
+    "DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id BETWEEN 99001 AND 99002",
+    "DELETE FROM outcome_maps                WHERE l_outcome_id BETWEEN 99001 AND 99002",
+    "DELETE FROM course_programs             WHERE course_id = 99001 AND program_id = 99001",
+    "DELETE FROM mapping_scale_programs      WHERE program_id = 99001",
+    "DELETE FROM program_learning_outcomes   WHERE pl_outcome_id BETWEEN 99001 AND 99002",
+    "DELETE FROM learning_outcomes           WHERE l_outcome_id BETWEEN 99001 AND 99002",
+    "DELETE FROM mapping_scales              WHERE map_scale_id BETWEEN 99001 AND 99002",
+    "DELETE FROM programs                    WHERE program_id = 99001",
+    "DELETE FROM courses                     WHERE course_id = 99001",
+]
+
+
+def main() -> int:
+    print(f"Connecting to {PG_DSN} ...")
+    try:
+        conn = psycopg2.connect(PG_DSN)
+    except Exception as e:
+        print(f"FAILED to connect: {e}", file=sys.stderr)
+        return 1
+
+    conn.autocommit = False
+    cur  = conn.cursor()
+    total = 0
+    try:
+        for sql in CLEANUP_STATEMENTS:
+            cur.execute(sql)
+            print(f"  {sql.split()[1]:<3} {sql.split()[3]:<35} -> {cur.rowcount} row(s) deleted")
+            total += cur.rowcount
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        print(f"FAILED, rolled back: {e}", file=sys.stderr)
+        return 1
+    finally:
+        cur.close()
+        conn.close()
+
+    print(f"\nDone. {total} row(s) deleted.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/services/lo_mapping_service/tests/e2e/conftest.py
+++ b/python/services/lo_mapping_service/tests/e2e/conftest.py
@@ -448,8 +448,8 @@ def fastapi_service(localstack_endpoint, s3_bucket):
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
-def upload_dummy_sagemaker_output(s3_client, bucket: str, key: str) -> str:
-    # Returns S3-formatted output from sample_ai_output.jsonl
-    with open(FIXTURES_DIR / "sample_ai_output.jsonl", "rb") as f:
+def upload_dummy_sagemaker_output(s3_client, bucket: str, key: str, fixture: str = "sample_ai_output.jsonl") -> str:
+    """Upload a JSONL fixture to S3; returns the s3:// URI."""
+    with open(FIXTURES_DIR / fixture, "rb") as f:
         s3_client.put_object(Bucket=bucket, Key=key, Body=f.read())
     return f"s3://{bucket}/{key}"

--- a/python/services/lo_mapping_service/tests/e2e/conftest.py
+++ b/python/services/lo_mapping_service/tests/e2e/conftest.py
@@ -62,25 +62,6 @@ def localstack_endpoint(localstack_container):
     return localstack_container.get_url()
 
 
-@pytest.fixture(scope="session", autouse=True)
-def localstack_env(localstack_endpoint):
-    """Force boto3 in this process (and child FastAPI requests via env) to LocalStack."""
-    overrides = {
-        "AWS_ENDPOINT_URL":    localstack_endpoint,
-        "AWS_REGION":          REGION,
-        "AWS_ACCESS_KEY_ID":   FAKE_AWS_KEY,
-        "AWS_SECRET_ACCESS_KEY": FAKE_AWS_SECRET,
-    }
-    original = {k: os.environ.get(k) for k in overrides}
-    os.environ.update(overrides)
-    yield
-    for k, v in original.items():
-        if v is None:
-            os.environ.pop(k, None)
-        else:
-            os.environ[k] = v
-
-
 @pytest.fixture(scope="session")
 def boto_session(localstack_endpoint):
     return boto3.Session(

--- a/python/services/lo_mapping_service/tests/e2e/conftest.py
+++ b/python/services/lo_mapping_service/tests/e2e/conftest.py
@@ -1,0 +1,438 @@
+"""
+Shared fixtures for E2E tests.
+
+Prerequisites for running these tests (see README.md):
+  - Docker running (for LocalStack)
+  - Postgres running (the same one Laravel uses)
+  - FastAPI service running on $FASTAPI_URL with AWS endpoints pointing at LocalStack
+  - Laravel server running on $LARAVEL_URL
+  - A test user account exists with credentials $E2E_TEST_USER_EMAIL / $E2E_TEST_USER_PASSWORD
+"""
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import boto3
+import psycopg2
+import pytest
+import requests
+from testcontainers.localstack import LocalStackContainer
+
+REGION              = "ca-central-1"
+FAKE_AWS_KEY        = "test"
+FAKE_AWS_SECRET     = "test"
+DYNAMO_TABLE_NAME   = os.environ.get("E2E_DYNAMO_TABLE", "lo-mapping-requests-e2e")
+S3_BUCKET           = os.environ.get("E2E_S3_BUCKET", "curriculum-map-e2e-bucket")
+DYNAMO_GSI          = "status-created_at-index"
+
+LARAVEL_URL         = os.environ.get("LARAVEL_URL", "http://127.0.0.1:8000")
+FASTAPI_URL         = os.environ.get("FASTAPI_URL", "http://127.0.0.1:8002")
+
+PG_DSN              = os.environ.get(
+    "E2E_PG_DSN",
+    "postgresql://root@localhost:5432/laravel",
+)
+
+E2E_USER_EMAIL      = os.environ.get("E2E_TEST_USER_EMAIL")
+E2E_USER_PASSWORD   = os.environ.get("E2E_TEST_USER_PASSWORD")
+
+# High IDs so tests do not collide with real data. Cleanup deletes by these IDs.
+TEST_COURSE_ID      = 99001
+TEST_PROGRAM_ID     = 99001
+TEST_CLO_IDS        = [99001, 99002]
+TEST_PLO_IDS        = [99001, 99002]
+TEST_MAP_SCALE_IDS  = [99001, 99002]  # one for "I" (Introduced), one for "D" (Developed)
+
+
+# ─────────────────── LocalStack ───────────────────
+
+@pytest.fixture(scope="session")
+def localstack_container():
+    with LocalStackContainer(image="localstack/localstack:3.0") as ls:
+        yield ls
+
+
+@pytest.fixture(scope="session")
+def localstack_endpoint(localstack_container):
+    return localstack_container.get_url()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def localstack_env(localstack_endpoint):
+    """Force boto3 in this process (and child FastAPI requests via env) to LocalStack."""
+    overrides = {
+        "AWS_ENDPOINT_URL":    localstack_endpoint,
+        "AWS_REGION":          REGION,
+        "AWS_ACCESS_KEY_ID":   FAKE_AWS_KEY,
+        "AWS_SECRET_ACCESS_KEY": FAKE_AWS_SECRET,
+    }
+    original = {k: os.environ.get(k) for k in overrides}
+    os.environ.update(overrides)
+    yield
+    for k, v in original.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+@pytest.fixture(scope="session")
+def boto_session(localstack_endpoint):
+    return boto3.Session(
+        aws_access_key_id=FAKE_AWS_KEY,
+        aws_secret_access_key=FAKE_AWS_SECRET,
+        region_name=REGION,
+    )
+
+
+@pytest.fixture(scope="session")
+def s3_client(boto_session, localstack_endpoint):
+    return boto_session.client("s3", endpoint_url=localstack_endpoint)
+
+
+@pytest.fixture(scope="session")
+def dynamodb_resource(boto_session, localstack_endpoint):
+    return boto_session.resource("dynamodb", endpoint_url=localstack_endpoint)
+
+
+@pytest.fixture(scope="session")
+def s3_bucket(s3_client):
+    s3_client.create_bucket(
+        Bucket=S3_BUCKET,
+        CreateBucketConfiguration={"LocationConstraint": REGION},
+    )
+    yield S3_BUCKET
+    objects = s3_client.list_objects_v2(Bucket=S3_BUCKET).get("Contents", [])
+    for obj in objects:
+        s3_client.delete_object(Bucket=S3_BUCKET, Key=obj["Key"])
+    s3_client.delete_bucket(Bucket=S3_BUCKET)
+
+
+@pytest.fixture
+def dynamo_table(dynamodb_resource):
+    """Create a fresh DynamoDB table per test."""
+    table = dynamodb_resource.create_table(
+        TableName=DYNAMO_TABLE_NAME,
+        KeySchema=[{"AttributeName": "request_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "request_id", "AttributeType": "S"},
+            {"AttributeName": "status",     "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[{
+            "IndexName": DYNAMO_GSI,
+            "KeySchema": [
+                {"AttributeName": "status",     "KeyType": "HASH"},
+                {"AttributeName": "created_at", "KeyType": "RANGE"},
+            ],
+            "Projection": {"ProjectionType": "ALL"},
+        }],
+    )
+    table.wait_until_exists()
+    yield table
+    table.delete()
+
+
+# ─────────────────── Postgres test data ───────────────────
+
+@pytest.fixture(scope="session")
+def pg_conn():
+    conn = psycopg2.connect(PG_DSN)
+    conn.autocommit = False
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def seeded_course_program(pg_conn):
+    """
+    Seed a minimal course/program with 2 CLOs, 2 PLOs, and 2 mapping scales.
+    Cleans up everything at the end.
+    """
+    cur = pg_conn.cursor()
+    try:
+        # Mapping scales (I = Introduced, D = Developed)
+        cur.execute(
+            """
+            INSERT INTO mapping_scales (map_scale_id, title, abbreviation, description, colour, created_at, updated_at)
+            VALUES
+              (%s, 'Introduced', 'I', 'Introduced level', '#aaaaaa', NOW(), NOW()),
+              (%s, 'Developed',  'D', 'Developed level',  '#bbbbbb', NOW(), NOW())
+            ON CONFLICT (map_scale_id) DO NOTHING
+            """,
+            TEST_MAP_SCALE_IDS,
+        )
+
+        # Course. NOT NULL columns without defaults: course_code, delivery_modality (char(1)),
+        # year, semester (char(2)), course_title, assigned, type.
+        cur.execute(
+            """
+            INSERT INTO courses (
+                course_id, course_code, course_title,
+                delivery_modality, year, semester,
+                assigned, type,
+                created_at, updated_at
+            )
+            VALUES (%s, 'E2ETEST', 'E2E Test Course',
+                    'O', 2026, 'F1',
+                    0, 'Other',
+                    NOW(), NOW())
+            ON CONFLICT (course_id) DO NOTHING
+            """,
+            (TEST_COURSE_ID,),
+        )
+
+        # Learning outcomes (CLOs)
+        for i, lo_id in enumerate(TEST_CLO_IDS, start=1):
+            cur.execute(
+                """
+                INSERT INTO learning_outcomes (l_outcome_id, course_id, l_outcome, clo_shortphrase, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, NOW(), NOW())
+                ON CONFLICT (l_outcome_id) DO NOTHING
+                """,
+                (lo_id, TEST_COURSE_ID, f"Test CLO {i}", f"clo{i}"),
+            )
+
+        # Program
+        cur.execute(
+            """
+            INSERT INTO programs (program_id, program, level, status, created_at, updated_at)
+            VALUES (%s, 'E2E Test Program', 'undergrad', 'active', NOW(), NOW())
+            ON CONFLICT (program_id) DO NOTHING
+            """,
+            (TEST_PROGRAM_ID,),
+        )
+
+        # Program learning outcomes (PLOs)
+        for i, plo_id in enumerate(TEST_PLO_IDS, start=1):
+            cur.execute(
+                """
+                INSERT INTO program_learning_outcomes (pl_outcome_id, program_id, pl_outcome, plo_shortphrase, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, NOW(), NOW())
+                ON CONFLICT (pl_outcome_id) DO NOTHING
+                """,
+                (plo_id, TEST_PROGRAM_ID, f"Test PLO {i}", f"plo{i}"),
+            )
+
+        # Link mapping scales to program
+        for ms_id in TEST_MAP_SCALE_IDS:
+            cur.execute(
+                """
+                INSERT INTO mapping_scale_programs (program_id, map_scale_id, created_at, updated_at)
+                VALUES (%s, %s, NOW(), NOW())
+                ON CONFLICT DO NOTHING
+                """,
+                (TEST_PROGRAM_ID, ms_id),
+            )
+
+        # course_programs pivot
+        cur.execute(
+            """
+            INSERT INTO course_programs (course_id, program_id, course_required, manual_map_status, ai_suggestion_status, created_at, updated_at)
+            VALUES (%s, %s, false, false, false, NOW(), NOW())
+            ON CONFLICT (course_id, program_id) DO UPDATE SET manual_map_status = false, ai_suggestion_status = false
+            """,
+            (TEST_COURSE_ID, TEST_PROGRAM_ID),
+        )
+
+        pg_conn.commit()
+        yield {
+            "course_id":  TEST_COURSE_ID,
+            "program_id": TEST_PROGRAM_ID,
+            "clo_ids":    TEST_CLO_IDS,
+            "plo_ids":    TEST_PLO_IDS,
+            "scale_ids":  TEST_MAP_SCALE_IDS,
+        }
+    finally:
+        # If the seed inserts above failed mid-way the transaction is aborted, so
+        # any subsequent statement would error with InFailedSqlTransaction. Roll
+        # back first so the cleanup deletes can run regardless of how we got here.
+        pg_conn.rollback()
+        cur.close()
+        cur = pg_conn.cursor()
+        try:
+            cur.execute("DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id = ANY(%s)", (TEST_CLO_IDS,))
+            cur.execute("DELETE FROM outcome_maps WHERE l_outcome_id = ANY(%s)", (TEST_CLO_IDS,))
+            cur.execute("DELETE FROM course_programs WHERE course_id = %s AND program_id = %s", (TEST_COURSE_ID, TEST_PROGRAM_ID))
+            cur.execute("DELETE FROM mapping_scale_programs WHERE program_id = %s", (TEST_PROGRAM_ID,))
+            cur.execute("DELETE FROM program_learning_outcomes WHERE pl_outcome_id = ANY(%s)", (TEST_PLO_IDS,))
+            cur.execute("DELETE FROM learning_outcomes WHERE l_outcome_id = ANY(%s)", (TEST_CLO_IDS,))
+            cur.execute("DELETE FROM mapping_scales WHERE map_scale_id = ANY(%s)", (TEST_MAP_SCALE_IDS,))
+            cur.execute("DELETE FROM programs WHERE program_id = %s", (TEST_PROGRAM_ID,))
+            cur.execute("DELETE FROM courses WHERE course_id = %s", (TEST_COURSE_ID,))
+            pg_conn.commit()
+        finally:
+            cur.close()
+
+
+# ─────────────────── Laravel auth ───────────────────
+
+def _resolve_credentials() -> tuple[str | None, str | None]:
+    """Read credentials from env, or prompt interactively if stdin is a TTY."""
+    # Read env fresh at call time, not module-import time, so changes after
+    # collection (or weird import-order issues) still get picked up.
+    email    = os.environ.get("E2E_TEST_USER_EMAIL")
+    password = os.environ.get("E2E_TEST_USER_PASSWORD")
+
+    if email and password:
+        return email, password
+
+    if not sys.stdin.isatty():
+        return email, password  # caller decides what to do (skip)
+
+    from getpass import getpass
+    if not email:
+        email = input("Laravel test user email: ").strip()
+    if not password:
+        password = getpass("Laravel test user password: ")
+    return email, password
+
+
+@pytest.fixture(scope="session")
+def laravel_session():
+    """Login to Laravel and return a requests.Session with auth cookies + CSRF token helper."""
+    email, password = _resolve_credentials()
+    if not email or not password:
+        pytest.skip(
+            "E2E_TEST_USER_EMAIL and E2E_TEST_USER_PASSWORD not set, and stdin is not a TTY. "
+            "Either set the env vars, or run pytest with -s to enable interactive prompts."
+        )
+
+    sess = requests.Session()
+    # GET login page to grab CSRF token
+    login_page = sess.get(f"{LARAVEL_URL}/login")
+    login_page.raise_for_status()
+    import re
+    m = re.search(r'name="_token"\s+value="([^"]+)"', login_page.text)
+    if not m:
+        pytest.skip("Could not parse CSRF token from /login page")
+    token = m.group(1)
+
+    # POST credentials
+    r = sess.post(
+        f"{LARAVEL_URL}/login",
+        data={"email": email, "password": password, "_token": token},
+        allow_redirects=True,
+    )
+    if r.status_code >= 400 or "/login" in r.url:
+        pytest.skip("Login failed - check credentials")
+
+    return sess
+
+
+def get_csrf_token(sess: requests.Session, page_url: str) -> str:
+    """Grab the X-CSRF-TOKEN by GETting any page and parsing the meta tag."""
+    import re
+    page = sess.get(page_url)
+    page.raise_for_status()
+    m = re.search(r'name="csrf-token"\s+content="([^"]+)"', page.text)
+    return m.group(1) if m else ""
+
+
+# ─────────────────── FastAPI subprocess ───────────────────
+
+FASTAPI_TEST_PORT = int(os.environ.get("E2E_FASTAPI_PORT", "8002"))
+
+
+@pytest.fixture(scope="session")
+def fastapi_service(localstack_endpoint, s3_bucket):
+    """
+    Boot the lo_mapping_service FastAPI as a subprocess, configured to use
+    LocalStack and the test bucket/table. Yields the base URL. Kills the process
+    on teardown.
+
+    Refuses to start if port is already in use (so we don't conflict with a dev
+    FastAPI instance the user has running).
+    """
+    # Refuse to clobber a dev FastAPI instance.
+    try:
+        r = requests.get(f"http://127.0.0.1:{FASTAPI_TEST_PORT}/health", timeout=1)
+        if r.status_code == 200:
+            pytest.fail(
+                f"Port {FASTAPI_TEST_PORT} already has a FastAPI service running. "
+                f"Stop it before running E2E tests, or set E2E_FASTAPI_PORT to a free port."
+            )
+    except (requests.ConnectionError, requests.Timeout):
+        pass  # Port free, proceed
+
+    service_root = Path(__file__).resolve().parents[2]
+
+    if sys.platform == "win32":
+        venv_python = service_root / "env" / "Scripts" / "python.exe"
+    else:
+        venv_python = service_root / "env" / "bin" / "python"
+    if not venv_python.exists():
+        # Fall back to whatever python is on PATH
+        venv_python = Path(sys.executable)
+
+    env = os.environ.copy()
+    env.update({
+        "AWS_ENDPOINT_URL":                   localstack_endpoint,
+        "AWS_REGION":                         REGION,
+        "AWS_ACCESS_KEY_ID":                  FAKE_AWS_KEY,
+        "AWS_SECRET_ACCESS_KEY":              FAKE_AWS_SECRET,
+        "ACCESS_KEY":                         FAKE_AWS_KEY,
+        "SECRET_KEY":                         FAKE_AWS_SECRET,
+        "LO_MAPPING_DYNAMODB_REQUESTS_TABLE": DYNAMO_TABLE_NAME,
+        "BATCH_TRANSFORM_INPUT_S3_BUCKET":    S3_BUCKET,
+        "OUTPUT_S3_URI":                      f"s3://{S3_BUCKET}/output/",
+        "DYNAMODB_STATUS_INDEX":              DYNAMO_GSI,
+        "ALLOWED_ORIGINS":                    "http://localhost,http://127.0.0.1",
+        "LARAVEL_API_URL":                    f"{LARAVEL_URL}/api/microservices/lo-mapping/ai-suggestions/store",
+    })
+
+    proc = subprocess.Popen(
+        [
+            str(venv_python), "-m", "uvicorn", "app.api.routes:app",
+            "--host", "127.0.0.1",
+            "--port", str(FASTAPI_TEST_PORT),
+            "--log-level", "info",
+        ],
+        env=env,
+        cwd=str(service_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    # Wait up to 30s for /health to come up
+    base_url = f"http://127.0.0.1:{FASTAPI_TEST_PORT}"
+    health_url = f"{base_url}/health"
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            output = proc.stdout.read() if proc.stdout else ""
+            pytest.fail(f"FastAPI exited early during startup:\n{output}")
+        try:
+            if requests.get(health_url, timeout=1).status_code == 200:
+                break
+        except (requests.ConnectionError, requests.Timeout):
+            pass
+        time.sleep(0.5)
+    else:
+        proc.terminate()
+        output = proc.stdout.read() if proc.stdout else ""
+        pytest.fail(f"FastAPI never became ready on {base_url}:\n{output}")
+
+    yield base_url
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+# ─────────────────── Helpers ───────────────────
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def upload_dummy_sagemaker_output(s3_client, bucket: str, key: str) -> str:
+    """Upload the canned AI output JSONL to S3, return s3:// URI."""
+    with open(FIXTURES_DIR / "sample_ai_output.jsonl", "rb") as f:
+        s3_client.put_object(Bucket=bucket, Key=key, Body=f.read())
+    return f"s3://{bucket}/{key}"

--- a/python/services/lo_mapping_service/tests/e2e/conftest.py
+++ b/python/services/lo_mapping_service/tests/e2e/conftest.py
@@ -1,5 +1,5 @@
 """
-Shared fixtures for E2E tests.
+Shared configs for E2E tests.
 
 Prerequisites for running these tests (see README.md):
   - Docker running (for LocalStack)
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 
 import boto3
@@ -23,8 +24,12 @@ from testcontainers.localstack import LocalStackContainer
 REGION              = "ca-central-1"
 FAKE_AWS_KEY        = "test"
 FAKE_AWS_SECRET     = "test"
-DYNAMO_TABLE_NAME   = os.environ.get("E2E_DYNAMO_TABLE", "lo-mapping-requests-e2e")
-S3_BUCKET           = os.environ.get("E2E_S3_BUCKET", "curriculum-map-e2e-bucket")
+# Suffix table and bucket names with a per-session uuid so we can never collide
+# with a leftover resource from a crashed run, a concurrent run, or another
+# developer's LocalStack. Sidesteps delete-then-create races in LocalStack.
+_SESSION_TAG        = uuid.uuid4().hex[:8]
+DYNAMO_TABLE_NAME   = os.environ.get("E2E_DYNAMO_TABLE",  f"lo-mapping-requests-e2e-{_SESSION_TAG}")
+S3_BUCKET           = os.environ.get("E2E_S3_BUCKET",    f"curriculum-map-e2e-bucket-{_SESSION_TAG}")
 DYNAMO_GSI          = "status-created_at-index"
 
 LARAVEL_URL         = os.environ.get("LARAVEL_URL", "http://127.0.0.1:8000")
@@ -111,29 +116,20 @@ def s3_bucket(s3_client):
 
 
 @pytest.fixture
-def dynamo_table(dynamodb_resource):
-    """Create a fresh DynamoDB table per test."""
-    table = dynamodb_resource.create_table(
-        TableName=DYNAMO_TABLE_NAME,
-        KeySchema=[{"AttributeName": "request_id", "KeyType": "HASH"}],
-        AttributeDefinitions=[
-            {"AttributeName": "request_id", "AttributeType": "S"},
-            {"AttributeName": "status",     "AttributeType": "S"},
-            {"AttributeName": "created_at", "AttributeType": "S"},
-        ],
-        BillingMode="PAY_PER_REQUEST",
-        GlobalSecondaryIndexes=[{
-            "IndexName": DYNAMO_GSI,
-            "KeySchema": [
-                {"AttributeName": "status",     "KeyType": "HASH"},
-                {"AttributeName": "created_at", "KeyType": "RANGE"},
-            ],
-            "Projection": {"ProjectionType": "ALL"},
-        }],
-    )
+def dynamo_table(fastapi_service, dynamodb_resource):
+    """Yield the DynamoDB table FastAPI created in its lifespan hook
+    (ensure_table_exists). The depends-on-fastapi_service ordering guarantees
+    the table is ready before the test runs. At teardown we wipe items rather
+    than delete the table, so subsequent tests in the same session still find
+    it (FastAPI's lifespan only runs once)."""
+    table = dynamodb_resource.Table(DYNAMO_TABLE_NAME)
     table.wait_until_exists()
     yield table
-    table.delete()
+    # Wipe all items so the next test starts clean.
+    scan = table.scan(ProjectionExpression="request_id")
+    with table.batch_writer() as batch:
+        for item in scan.get("Items", []):
+            batch.delete_item(Key={"request_id": item["request_id"]})
 
 
 # ─────────────────── Postgres test data ───────────────────
@@ -149,7 +145,7 @@ def pg_conn():
 @pytest.fixture
 def seeded_course_program(pg_conn):
     """
-    Seed a minimal course/program with 2 CLOs, 2 PLOs, and 2 mapping scales.
+    Set up a minimal course/program with 2 CLOs, 2 PLOs, and 2 mapping scales.
     Cleans up everything at the end.
     """
     cur = pg_conn.cursor()
@@ -200,7 +196,7 @@ def seeded_course_program(pg_conn):
         cur.execute(
             """
             INSERT INTO programs (program_id, program, level, status, created_at, updated_at)
-            VALUES (%s, 'E2E Test Program', 'undergrad', 'active', NOW(), NOW())
+            VALUES (%s, 'E2E Test Program', 'undergrad', 1, NOW(), NOW())
             ON CONFLICT (program_id) DO NOTHING
             """,
             (TEST_PROGRAM_ID,),
@@ -228,14 +224,42 @@ def seeded_course_program(pg_conn):
                 (TEST_PROGRAM_ID, ms_id),
             )
 
-        # course_programs pivot
+        cur.execute(
+            "DELETE FROM course_programs WHERE course_id = %s AND program_id = %s",
+            (TEST_COURSE_ID, TEST_PROGRAM_ID),
+        )
         cur.execute(
             """
             INSERT INTO course_programs (course_id, program_id, course_required, manual_map_status, ai_suggestion_status, created_at, updated_at)
-            VALUES (%s, %s, false, false, false, NOW(), NOW())
-            ON CONFLICT (course_id, program_id) DO UPDATE SET manual_map_status = false, ai_suggestion_status = false
+            VALUES (%s, %s, 0, false, false, NOW(), NOW())
             """,
             (TEST_COURSE_ID, TEST_PROGRAM_ID),
+        )
+
+        # Link the test login user to this course/program as Owner (permission=1),
+        # so HasAccessMiddleware doesn't redirect step5 to /home.
+        email, _ = _resolve_credentials()
+        cur.execute("SELECT id FROM users WHERE email = %s", (email,))
+        row = cur.fetchone()
+        if row is None:
+            raise RuntimeError(
+                f"Test login user {email!r} not found in users table. "
+                f"Did you run UserSeeder? (php artisan db:seed --class=UserSeeder)"
+            )
+        test_user_id = row[0]
+        cur.execute(
+            """
+            INSERT INTO course_users (course_id, user_id, permission, created_at, updated_at)
+            VALUES (%s, %s, 1, NOW(), NOW())
+            """,
+            (TEST_COURSE_ID, test_user_id),
+        )
+        cur.execute(
+            """
+            INSERT INTO program_users (user_id, program_id, permission, created_at, updated_at)
+            VALUES (%s, %s, 1, NOW(), NOW())
+            """,
+            (test_user_id, TEST_PROGRAM_ID),
         )
 
         pg_conn.commit()
@@ -256,6 +280,8 @@ def seeded_course_program(pg_conn):
         try:
             cur.execute("DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id = ANY(%s)", (TEST_CLO_IDS,))
             cur.execute("DELETE FROM outcome_maps WHERE l_outcome_id = ANY(%s)", (TEST_CLO_IDS,))
+            cur.execute("DELETE FROM course_users WHERE course_id = %s", (TEST_COURSE_ID,))
+            cur.execute("DELETE FROM program_users WHERE program_id = %s", (TEST_PROGRAM_ID,))
             cur.execute("DELETE FROM course_programs WHERE course_id = %s AND program_id = %s", (TEST_COURSE_ID, TEST_PROGRAM_ID))
             cur.execute("DELETE FROM mapping_scale_programs WHERE program_id = %s", (TEST_PROGRAM_ID,))
             cur.execute("DELETE FROM program_learning_outcomes WHERE pl_outcome_id = ANY(%s)", (TEST_PLO_IDS,))
@@ -270,39 +296,35 @@ def seeded_course_program(pg_conn):
 
 # ─────────────────── Laravel auth ───────────────────
 
-def _resolve_credentials() -> tuple[str | None, str | None]:
-    """Read credentials from env, or prompt interactively if stdin is a TTY."""
-    # Read env fresh at call time, not module-import time, so changes after
-    # collection (or weird import-order issues) still get picked up.
-    email    = os.environ.get("E2E_TEST_USER_EMAIL")
-    password = os.environ.get("E2E_TEST_USER_PASSWORD")
-
-    if email and password:
-        return email, password
-
-    if not sys.stdin.isatty():
-        return email, password  # caller decides what to do (skip)
-
-    from getpass import getpass
-    if not email:
-        email = input("Laravel test user email: ").strip()
-    if not password:
-        password = getpass("Laravel test user password: ")
+def _resolve_credentials() -> tuple[str, str]:
+    """Resolve test-user credentials. Defaults to the seeded admin user
+    (admintest@gmail.com / password from UserSeeder), so the test runs with
+    no extra setup on a freshly-seeded local DB. Override via env vars when
+    pointing at a different account."""
+    email    = os.environ.get("E2E_TEST_USER_EMAIL")    or "admintest@gmail.com"
+    password = os.environ.get("E2E_TEST_USER_PASSWORD") or "password"
     return email, password
 
 
 @pytest.fixture(scope="session")
-def laravel_session():
+def laravel_session(pg_conn):
     """Login to Laravel and return a requests.Session with auth cookies + CSRF token helper."""
     email, password = _resolve_credentials()
-    if not email or not password:
-        pytest.skip(
-            "E2E_TEST_USER_EMAIL and E2E_TEST_USER_PASSWORD not set, and stdin is not a TTY. "
-            "Either set the env vars, or run pytest with -s to enable interactive prompts."
+
+    # Laravel's MustVerifyEmail middleware redirects unverified users to /email/verify
+    # on every request. The seeded admin user has no email_verified_at, so mark it
+    # verified now. autocommit=False on pg_conn, so commit explicitly.
+    cur = pg_conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE users SET email_verified_at = COALESCE(email_verified_at, NOW()) WHERE email = %s",
+            (email,),
         )
+        pg_conn.commit()
+    finally:
+        cur.close()
 
     sess = requests.Session()
-    # GET login page to grab CSRF token
     login_page = sess.get(f"{LARAVEL_URL}/login")
     login_page.raise_for_status()
     import re
@@ -345,9 +367,8 @@ def fastapi_service(localstack_endpoint, s3_bucket):
     on teardown.
 
     Refuses to start if port is already in use (so we don't conflict with a dev
-    FastAPI instance the user has running).
+    FastAPI instance).
     """
-    # Refuse to clobber a dev FastAPI instance.
     try:
         r = requests.get(f"http://127.0.0.1:{FASTAPI_TEST_PORT}/health", timeout=1)
         if r.status_code == 200:
@@ -365,8 +386,7 @@ def fastapi_service(localstack_endpoint, s3_bucket):
     else:
         venv_python = service_root / "env" / "bin" / "python"
     if not venv_python.exists():
-        # Fall back to whatever python is on PATH
-        venv_python = Path(sys.executable)
+        raise FileNotFoundError(f"Could not find FastAPI python venv at {venv_python}. Did you run 'python -m venv env' and 'pip install -r requirements.txt'?")
 
     env = os.environ.copy()
     env.update({
@@ -384,6 +404,13 @@ def fastapi_service(localstack_endpoint, s3_bucket):
         "LARAVEL_API_URL":                    f"{LARAVEL_URL}/api/microservices/lo-mapping/ai-suggestions/store",
     })
 
+    # Dump logs into temp file for debugging
+    import tempfile
+    log_file = tempfile.NamedTemporaryFile(
+        prefix="e2e-fastapi-", suffix=".log", delete=False, mode="w+", encoding="utf-8",
+    )
+    log_path = Path(log_file.name)
+
     proc = subprocess.Popen(
         [
             str(venv_python), "-m", "uvicorn", "app.api.routes:app",
@@ -393,10 +420,16 @@ def fastapi_service(localstack_endpoint, s3_bucket):
         ],
         env=env,
         cwd=str(service_root),
-        stdout=subprocess.PIPE,
+        stdout=log_file,
         stderr=subprocess.STDOUT,
         text=True,
     )
+
+    def _read_log() -> str:
+        try:
+            return log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return "<could not read FastAPI log>"
 
     # Wait up to 30s for /health to come up
     base_url = f"http://127.0.0.1:{FASTAPI_TEST_PORT}"
@@ -404,8 +437,7 @@ def fastapi_service(localstack_endpoint, s3_bucket):
     deadline = time.time() + 30
     while time.time() < deadline:
         if proc.poll() is not None:
-            output = proc.stdout.read() if proc.stdout else ""
-            pytest.fail(f"FastAPI exited early during startup:\n{output}")
+            pytest.fail(f"FastAPI exited early during startup:\n{_read_log()}")
         try:
             if requests.get(health_url, timeout=1).status_code == 200:
                 break
@@ -414,9 +446,9 @@ def fastapi_service(localstack_endpoint, s3_bucket):
         time.sleep(0.5)
     else:
         proc.terminate()
-        output = proc.stdout.read() if proc.stdout else ""
-        pytest.fail(f"FastAPI never became ready on {base_url}:\n{output}")
+        pytest.fail(f"FastAPI never became ready on {base_url}:\n{_read_log()}")
 
+    print(f"\n[e2e] FastAPI log: {log_path}")
     yield base_url
 
     proc.terminate()
@@ -424,15 +456,17 @@ def fastapi_service(localstack_endpoint, s3_bucket):
         proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
         proc.kill()
+    log_file.close()
+    # Always print the FastAPI log at teardown so failing tests have evidence.
+    print(f"\n[e2e] FastAPI subprocess log ({log_path}):\n{_read_log()}")
 
 
 # ─────────────────── Helpers ───────────────────
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
-
 def upload_dummy_sagemaker_output(s3_client, bucket: str, key: str) -> str:
-    """Upload the canned AI output JSONL to S3, return s3:// URI."""
+    # Returns S3-formatted output from sample_ai_output.jsonl
     with open(FIXTURES_DIR / "sample_ai_output.jsonl", "rb") as f:
         s3_client.put_object(Bucket=bucket, Key=key, Body=f.read())
     return f"s3://{bucket}/{key}"

--- a/python/services/lo_mapping_service/tests/e2e/conftest.py
+++ b/python/services/lo_mapping_service/tests/e2e/conftest.py
@@ -24,9 +24,7 @@ from testcontainers.localstack import LocalStackContainer
 REGION              = "ca-central-1"
 FAKE_AWS_KEY        = "test"
 FAKE_AWS_SECRET     = "test"
-# Suffix table and bucket names with a per-session uuid so we can never collide
-# with a leftover resource from a crashed run, a concurrent run, or another
-# developer's LocalStack. Sidesteps delete-then-create races in LocalStack.
+# Session-unique names so we never collide with leftover resources from a prior run.
 _SESSION_TAG        = uuid.uuid4().hex[:8]
 DYNAMO_TABLE_NAME   = os.environ.get("E2E_DYNAMO_TABLE",  f"lo-mapping-requests-e2e-{_SESSION_TAG}")
 S3_BUCKET           = os.environ.get("E2E_S3_BUCKET",    f"curriculum-map-e2e-bucket-{_SESSION_TAG}")
@@ -117,15 +115,10 @@ def s3_bucket(s3_client):
 
 @pytest.fixture
 def dynamo_table(fastapi_service, dynamodb_resource):
-    """Yield the DynamoDB table FastAPI created in its lifespan hook
-    (ensure_table_exists). The depends-on-fastapi_service ordering guarantees
-    the table is ready before the test runs. At teardown we wipe items rather
-    than delete the table, so subsequent tests in the same session still find
-    it (FastAPI's lifespan only runs once)."""
+    """Adopt the table FastAPI's lifespan hook creates; wipe items between tests."""
     table = dynamodb_resource.Table(DYNAMO_TABLE_NAME)
     table.wait_until_exists()
     yield table
-    # Wipe all items so the next test starts clean.
     scan = table.scan(ProjectionExpression="request_id")
     with table.batch_writer() as batch:
         for item in scan.get("Items", []):
@@ -236,8 +229,7 @@ def seeded_course_program(pg_conn):
             (TEST_COURSE_ID, TEST_PROGRAM_ID),
         )
 
-        # Link the test login user to this course/program as Owner (permission=1),
-        # so HasAccessMiddleware doesn't redirect step5 to /home.
+        # HasAccessMiddleware redirects to /home unless the user owns the course/program.
         email, _ = _resolve_credentials()
         cur.execute("SELECT id FROM users WHERE email = %s", (email,))
         row = cur.fetchone()
@@ -297,32 +289,16 @@ def seeded_course_program(pg_conn):
 # ─────────────────── Laravel auth ───────────────────
 
 def _resolve_credentials() -> tuple[str, str]:
-    """Resolve test-user credentials. Defaults to the seeded admin user
-    (admintest@gmail.com / password from UserSeeder), so the test runs with
-    no extra setup on a freshly-seeded local DB. Override via env vars when
-    pointing at a different account."""
+    """Returns (email, password); defaults to the seeded admin user, override via env vars."""
     email    = os.environ.get("E2E_TEST_USER_EMAIL")    or "admintest@gmail.com"
     password = os.environ.get("E2E_TEST_USER_PASSWORD") or "password"
     return email, password
 
 
 @pytest.fixture(scope="session")
-def laravel_session(pg_conn):
-    """Login to Laravel and return a requests.Session with auth cookies + CSRF token helper."""
+def laravel_session():
+    """Returns an authenticated requests.Session, or fails loudly if the user can't be used."""
     email, password = _resolve_credentials()
-
-    # Laravel's MustVerifyEmail middleware redirects unverified users to /email/verify
-    # on every request. The seeded admin user has no email_verified_at, so mark it
-    # verified now. autocommit=False on pg_conn, so commit explicitly.
-    cur = pg_conn.cursor()
-    try:
-        cur.execute(
-            "UPDATE users SET email_verified_at = COALESCE(email_verified_at, NOW()) WHERE email = %s",
-            (email,),
-        )
-        pg_conn.commit()
-    finally:
-        cur.close()
 
     sess = requests.Session()
     login_page = sess.get(f"{LARAVEL_URL}/login")
@@ -330,17 +306,24 @@ def laravel_session(pg_conn):
     import re
     m = re.search(r'name="_token"\s+value="([^"]+)"', login_page.text)
     if not m:
-        pytest.skip("Could not parse CSRF token from /login page")
+        pytest.fail("Could not parse CSRF token from /login page")
     token = m.group(1)
 
-    # POST credentials
     r = sess.post(
         f"{LARAVEL_URL}/login",
         data={"email": email, "password": password, "_token": token},
         allow_redirects=True,
     )
     if r.status_code >= 400 or "/login" in r.url:
-        pytest.skip("Login failed - check credentials")
+        pytest.fail(f"Login failed for {email!r} — check credentials")
+
+    # This means the user exists but their email hasn't been veified yet
+    probe = sess.get(f"{LARAVEL_URL}/home", allow_redirects=True)
+    if "/email/verify" in probe.url:
+        pytest.fail(
+            f"Test user {email!r} is not email-verified — Laravel will redirect every request to /email/verify.\n"
+            f"Fix: UPDATE users SET email_verified_at = NOW() WHERE email = '{email}';"
+        )
 
     return sess
 

--- a/python/services/lo_mapping_service/tests/e2e/fixtures/all_unmapped_ai_output.jsonl
+++ b/python/services/lo_mapping_service/tests/e2e/fixtures/all_unmapped_ai_output.jsonl
@@ -1,0 +1,4 @@
+[{"generated_text": "{\"id\": \"clo-99001__plo-99001\", \"CLO\": \"Test CLO 1\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": false, \"mapLabels\": [], \"explanation\": \"unmapped.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99001__plo-99002\", \"CLO\": \"Test CLO 1\", \"Accreditation_Standard\": \"Test PLO 2\", \"is_mapped\": false, \"mapLabels\": [], \"explanation\": \"unmapped.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99001\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": false, \"mapLabels\": [], \"explanation\": \"unmapped.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99002\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 2\", \"is_mapped\": false, \"mapLabels\": [], \"explanation\": \"unmapped.\"}"}]

--- a/python/services/lo_mapping_service/tests/e2e/fixtures/malformed_ai_output.jsonl
+++ b/python/services/lo_mapping_service/tests/e2e/fixtures/malformed_ai_output.jsonl
@@ -1,0 +1,6 @@
+[{"generated_text": "{\"id\": \"clo-99001__plo-99001\", \"CLO\": \"Test CLO 1\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": true, \"mapLabels\": [\"I\"], \"explanation\": \"valid line.\"}"}]
+this is not valid json at all
+[{"generated_text": "}{ not parseable json inside generated_text {{"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99001\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": true, \"mapLabels\": [\"D\"], \"explanation\": \"valid line.\"}"}]
+[{"missing_generated_text_field": "should be skipped"}]
+[{"generated_text": "{\"id\": \"malformed-composite-id-no-clo-plo-split\", \"CLO\": \"x\", \"Accreditation_Standard\": \"y\", \"is_mapped\": true, \"mapLabels\": [\"I\"]}"}]

--- a/python/services/lo_mapping_service/tests/e2e/fixtures/sample_ai_output.jsonl
+++ b/python/services/lo_mapping_service/tests/e2e/fixtures/sample_ai_output.jsonl
@@ -1,0 +1,4 @@
+[{"generated_text": "{\"id\": \"clo-99001__plo-99001\", \"CLO\": \"Test CLO 1\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": true, \"mapLabels\": [\"I\"], \"explanation\": \"E2E test - mapped at Introduced.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99001__plo-99002\", \"CLO\": \"Test CLO 1\", \"Accreditation_Standard\": \"Test PLO 2\", \"is_mapped\": false, \"mapLabels\": [], \"explanation\": \"E2E test - unmapped.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99001\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": true, \"mapLabels\": [\"D\"], \"explanation\": \"E2E test - mapped at Developed.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99002\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 2\", \"is_mapped\": true, \"mapLabels\": [\"I\", \"D\"], \"explanation\": \"E2E test - mapped at Introduced and Developed.\"}"}]

--- a/python/services/lo_mapping_service/tests/e2e/fixtures/unknown_scale_ai_output.jsonl
+++ b/python/services/lo_mapping_service/tests/e2e/fixtures/unknown_scale_ai_output.jsonl
@@ -1,0 +1,3 @@
+[{"generated_text": "{\"id\": \"clo-99001__plo-99001\", \"CLO\": \"Test CLO 1\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": true, \"mapLabels\": [\"P\"], \"explanation\": \"unknown abbreviation P.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99001\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 1\", \"is_mapped\": true, \"mapLabels\": [\"D\"], \"explanation\": \"valid D.\"}"}]
+[{"generated_text": "{\"id\": \"clo-99002__plo-99002\", \"CLO\": \"Test CLO 2\", \"Accreditation_Standard\": \"Test PLO 2\", \"is_mapped\": true, \"mapLabels\": [\"I\", \"Q\"], \"explanation\": \"mixed valid I and unknown Q.\"}"}]

--- a/python/services/lo_mapping_service/tests/e2e/requirements.txt
+++ b/python/services/lo_mapping_service/tests/e2e/requirements.txt
@@ -1,0 +1,8 @@
+# Install with: pip install -r tests/e2e/requirements.txt
+testcontainers[localstack]>=4.0.0
+psycopg2-binary>=2.9.0
+beautifulsoup4>=4.12.0
+requests>=2.31.0
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+boto3>=1.42.0

--- a/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
+++ b/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
@@ -1,0 +1,147 @@
+"""
+End-to-end test that simulates a SageMaker job completing for a course/program,
+drives the polling endpoint, and verifies the AI-suggested mappings render on
+Step 5 with the expected purple icons.
+
+Skips:
+  - The actual SageMaker run (LocalStack does not support batch transform).
+  - The Lambda invocation chain (we directly create the AWAITING_COMPLETION
+    DynamoDB record and place dummy output in S3).
+
+Covers:
+  - LocalStack DynamoDB + S3 read by FastAPI
+  - FastAPI process_records pipeline
+  - Laravel storeAiSuggestions controller
+  - Postgres outcome_map_ai_suggestions writes
+  - course_programs flag updates
+  - Step 5 HTML response contains purple icons in the right cells
+"""
+import datetime as dt
+import uuid
+import time
+
+import pytest
+import requests
+from bs4 import BeautifulSoup
+
+from tests.e2e.conftest import (
+    LARAVEL_URL,
+    DYNAMO_TABLE_NAME,
+    upload_dummy_sagemaker_output,
+)
+
+
+def _put_awaiting_completion_record(
+    dynamo_table,
+    course_id: int,
+    program_id: int,
+    output_s3_uri: str,
+) -> str:
+    """Inject a record that looks like SageMaker just finished successfully."""
+    request_id = (
+        dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S-") + str(uuid.uuid4())
+    )
+    dynamo_table.put_item(Item={
+        "request_id":         request_id,
+        "course_id":          course_id,
+        "program_id":         program_id,
+        "status":             "AWAITING_COMPLETION",
+        "input_s3_path":      "s3://e2e-fake/input.jsonl",
+        "output_s3_path":     output_s3_uri,
+        "transform_job_name": "e2e-fake-transform-job",
+        "created_at":         dt.datetime.utcnow().isoformat(),
+        "updated_at":         dt.datetime.utcnow().isoformat(),
+    })
+    return request_id
+
+
+def test_ai_suggestions_render_on_step5(
+    fastapi_service,
+    seeded_course_program,
+    s3_bucket,
+    s3_client,
+    dynamo_table,
+    laravel_session,
+    pg_conn,
+):
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    # 1. Place dummy SageMaker output in S3
+    output_uri = upload_dummy_sagemaker_output(
+        s3_client,
+        s3_bucket,
+        f"output/e2e-test-{course_id}-{program_id}.jsonl.out",
+    )
+
+    # 2. Inject AWAITING_COMPLETION DynamoDB record pointing at that output
+    request_id = _put_awaiting_completion_record(dynamo_table, course_id, program_id, output_uri)
+
+    # 3. Drive the polling endpoint - this should pick up the record, deliver to
+    #    Laravel, write rows, set the flags, and delete the DynamoDB record.
+    r = laravel_session.post(
+        f"{LARAVEL_URL}/courseWizard/{course_id}/{program_id}/check-ai-results",
+        headers={"Accept": "application/json"},
+    )
+    assert r.status_code == 200, r.text
+
+    # First poll triggers async processing in FastAPI; subsequent polls see the
+    # local DB flag and report complete. Poll up to ~15s.
+    completed = False
+    for _ in range(15):
+        r = laravel_session.post(
+            f"{LARAVEL_URL}/courseWizard/{course_id}/{program_id}/check-ai-results",
+            headers={"Accept": "application/json"},
+        )
+        if r.json().get("status") == "complete":
+            completed = True
+            break
+        time.sleep(1)
+    assert completed, "Polling never reported 'complete' within 15s"
+
+    # 4. Verify Postgres state
+    cur = pg_conn.cursor()
+    cur.execute(
+        "SELECT manual_map_status, ai_suggestion_status FROM course_programs "
+        "WHERE course_id = %s AND program_id = %s",
+        (course_id, program_id),
+    )
+    row = cur.fetchone()
+    assert row == (True, True), f"Flags not set: {row}"
+
+    cur.execute(
+        "SELECT l_outcome_id, pl_outcome_id, map_scale_id FROM outcome_map_ai_suggestions "
+        "WHERE l_outcome_id = ANY(%s) ORDER BY l_outcome_id, pl_outcome_id, map_scale_id",
+        (seeded_course_program["clo_ids"],),
+    )
+    rows = cur.fetchall()
+    cur.close()
+
+    # Expected (matches sample_ai_output.jsonl):
+    #   clo-99001 / plo-99001 / scale "I"      (mapped)
+    #   clo-99001 / plo-99002 / scale N/A      (unmapped, written if N/A scale exists)
+    #   clo-99002 / plo-99001 / scale "D"      (mapped)
+    #   clo-99002 / plo-99002 / scale "I"      (mapped, multi)
+    #   clo-99002 / plo-99002 / scale "D"      (mapped, multi)
+    expected_minimum = {
+        (99001, 99001, 99001),  # I
+        (99002, 99001, 99002),  # D
+        (99002, 99002, 99001),  # I
+        (99002, 99002, 99002),  # D
+    }
+    actual = {tuple(r) for r in rows}
+    missing = expected_minimum - actual
+    assert not missing, f"Missing expected suggestion rows: {missing}. Actual: {actual}"
+
+    # 5. Render Step 5 and check for purple icons
+    page = laravel_session.get(f"{LARAVEL_URL}/courseWizard/{course_id}/step5")
+    assert page.status_code == 200, f"Step 5 returned {page.status_code}"
+
+    soup = BeautifulSoup(page.text, "html.parser")
+    purple_imgs = [
+        img for img in soup.find_all("img")
+        if "AISuggestionPurple.png" in (img.get("src") or "")
+    ]
+    assert len(purple_imgs) >= 4, (
+        f"Expected at least 4 purple icons (one per mapped scale), found {len(purple_imgs)}"
+    )

--- a/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
+++ b/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
@@ -358,3 +358,97 @@ def test_all_unmapped_routes_to_na_scale(
     assert len(rows) == 4, f"Expected 4 rows (one per CLO/PLO pair), got {len(rows)}: {rows}"
     assert all(r[2] == 0 for r in rows), \
         f"All rows should route to N/A scale (map_scale_id=0). Got: {rows}"
+
+
+LATE_CLO_ID = 99003
+
+
+def _insert_late_clo(pg_conn, course_id):
+    cur = pg_conn.cursor()
+    try:
+        cur.execute(
+            """
+            INSERT INTO learning_outcomes (l_outcome_id, course_id, l_outcome, clo_shortphrase, created_at, updated_at)
+            VALUES (%s, %s, 'Late-added CLO', 'late', NOW(), NOW())
+            ON CONFLICT (l_outcome_id) DO NOTHING
+            """,
+            (LATE_CLO_ID, course_id),
+        )
+        pg_conn.commit()
+    except Exception:
+        pg_conn.rollback()
+        raise
+    finally:
+        cur.close()
+
+
+def _delete_late_clo(pg_conn):
+    cur = pg_conn.cursor()
+    cur.execute("DELETE FROM outcome_map_ai_suggestions WHERE l_outcome_id = %s", (LATE_CLO_ID,))
+    cur.execute("DELETE FROM outcome_maps WHERE l_outcome_id = %s", (LATE_CLO_ID,))
+    cur.execute("DELETE FROM learning_outcomes WHERE l_outcome_id = %s", (LATE_CLO_ID,))
+    pg_conn.commit()
+    cur.close()
+
+
+def _assert_late_clo_has_no_icons(pg_conn, laravel_session, course_id, program_id):
+    cur = pg_conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM outcome_map_ai_suggestions WHERE l_outcome_id = %s", (LATE_CLO_ID,))
+    row_count = cur.fetchone()[0]
+    cur.close()
+    assert row_count == 0, f"Late-added CLO should have no suggestion rows; found {row_count}"
+
+    page = laravel_session.get(f"{LARAVEL_URL}/courseWizard/{course_id}/step5")
+    assert page.status_code == 200
+
+    soup = BeautifulSoup(page.text, "html.parser")
+    accordion = soup.find("div", id=f"accordionGroup{program_id}-{LATE_CLO_ID}")
+    assert accordion is not None, f"Step 5 should still render the late CLO accordion ({LATE_CLO_ID})"
+
+    purple = [
+        img for img in accordion.find_all("img")
+        if "AISuggestionPurple.png" in (img.get("src") or "")
+    ]
+    assert len(purple) == 0, f"Late-added CLO should have no purple icons; found {len(purple)}"
+
+
+def test_clo_added_after_results_processed_has_no_icons(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """CLO added after the AI pipeline has fully completed -> no purple icons for the new CLO."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    _trigger_ai_pipeline(
+        s3_client, s3_bucket, dynamo_table, laravel_session,
+        course_id, program_id, "sample_ai_output.jsonl",
+    )
+    _insert_late_clo(pg_conn, course_id)
+
+    try:
+        _assert_late_clo_has_no_icons(pg_conn, laravel_session, course_id, program_id)
+    finally:
+        _delete_late_clo(pg_conn)
+
+
+def test_clo_added_while_request_in_flight_has_no_icons(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """CLO added after the request was submitted but before results are processed -> still no purple icons."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    output_uri = upload_dummy_sagemaker_output(
+        s3_client, s3_bucket,
+        f"output/e2e-late-clo-inflight-{course_id}-{program_id}.jsonl.out",
+        fixture="sample_ai_output.jsonl",
+    )
+    _put_awaiting_completion_record(dynamo_table, course_id, program_id, output_uri)
+
+    _insert_late_clo(pg_conn, course_id)
+
+    try:
+        _drive_polling_to_complete(laravel_session, course_id, program_id)
+        _assert_late_clo_has_no_icons(pg_conn, laravel_session, course_id, program_id)
+    finally:
+        _delete_late_clo(pg_conn)

--- a/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
+++ b/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
@@ -80,7 +80,7 @@ def test_ai_suggestions_render_on_step5(
     # 2. Inject AWAITING_COMPLETION DynamoDB record pointing at that output
     request_id = _put_awaiting_completion_record(dynamo_table, course_id, program_id, output_uri)
 
-    # web middleware group so POSTs need X-CSRF-TOKEN.
+    # POSTs need X-CSRF-TOKEN.
     csrf_token = get_csrf_token(laravel_session, f"{LARAVEL_URL}/home")
     post_headers = {"Accept": "application/json", "X-CSRF-TOKEN": csrf_token}
 

--- a/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
+++ b/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
@@ -58,6 +58,47 @@ def _put_awaiting_completion_record(
     return request_id
 
 
+def _drive_polling_to_complete(laravel_session, course_id, program_id, timeout_s: int = 15) -> None:
+    """Poll /check-ai-results until status==complete or fail after timeout_s seconds."""
+    csrf_token = get_csrf_token(laravel_session, f"{LARAVEL_URL}/home")
+    headers = {"Accept": "application/json", "X-CSRF-TOKEN": csrf_token}
+    url = f"{LARAVEL_URL}/courseWizard/{course_id}/{program_id}/check-ai-results"
+
+    r = laravel_session.post(url, headers=headers)
+    assert r.status_code == 200, r.text
+    for _ in range(timeout_s):
+        r = laravel_session.post(url, headers=headers)
+        if r.json().get("status") == "complete":
+            return
+        time.sleep(1)
+    raise AssertionError(f"Polling never reported 'complete' within {timeout_s}s")
+
+
+def _trigger_ai_pipeline(s3_client, s3_bucket, dynamo_table, laravel_session,
+                         course_id, program_id, fixture: str) -> None:
+    """Upload fixture JSONL to S3, inject AWAITING_COMPLETION record, drive polling to complete."""
+    output_uri = upload_dummy_sagemaker_output(
+        s3_client, s3_bucket,
+        f"output/e2e-{fixture}-{course_id}-{program_id}.jsonl.out",
+        fixture=fixture,
+    )
+    _put_awaiting_completion_record(dynamo_table, course_id, program_id, output_uri)
+    _drive_polling_to_complete(laravel_session, course_id, program_id)
+
+
+def _suggestions_for_clos(pg_conn, clo_ids) -> list[tuple]:
+    """Return [(l_outcome_id, pl_outcome_id, map_scale_id), ...] sorted, for given CLOs."""
+    cur = pg_conn.cursor()
+    cur.execute(
+        "SELECT l_outcome_id, pl_outcome_id, map_scale_id FROM outcome_map_ai_suggestions "
+        "WHERE l_outcome_id = ANY(%s) ORDER BY l_outcome_id, pl_outcome_id, map_scale_id",
+        (clo_ids,),
+    )
+    rows = cur.fetchall()
+    cur.close()
+    return rows
+
+
 def test_ai_suggestions_render_on_step5(
     fastapi_service,
     seeded_course_program,
@@ -172,3 +213,148 @@ def test_ai_suggestions_render_on_step5(
     assert len(purple_imgs) >= 4, _ctx(
         f"Expected at least 4 purple icons (one per mapped scale), found {len(purple_imgs)}"
     )
+
+
+def test_malformed_jsonl_lines_are_skipped(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """Malformed JSONL lines should be skipped; valid lines should still produce rows."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    _trigger_ai_pipeline(
+        s3_client, s3_bucket, dynamo_table, laravel_session,
+        course_id, program_id, "malformed_ai_output.jsonl",
+    )
+
+    rows = set(_suggestions_for_clos(pg_conn, seeded_course_program["clo_ids"]))
+    # malformed_ai_output.jsonl has 2 valid lines: clo-99001/plo-99001/I and clo-99002/plo-99001/D.
+    assert (99001, 99001, 99001) in rows, f"Valid 'I' line missing. Got: {rows}"
+    assert (99002, 99001, 99002) in rows, f"Valid 'D' line missing. Got: {rows}"
+    # The 4 malformed lines should produce nothing.
+    assert len(rows) == 2, f"Malformed lines produced extra rows: {rows}"
+
+
+def test_unknown_scale_abbreviation_is_skipped(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """Labels not in the program's mapping scales should be skipped; valid ones should still write."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    _trigger_ai_pipeline(
+        s3_client, s3_bucket, dynamo_table, laravel_session,
+        course_id, program_id, "unknown_scale_ai_output.jsonl",
+    )
+
+    rows = set(_suggestions_for_clos(pg_conn, seeded_course_program["clo_ids"]))
+    # Fixture: clo-99001/plo-99001 has only 'P' (unknown) -> 0 rows.
+    #          clo-99002/plo-99001 has 'D' -> 1 row at scale 99002.
+    #          clo-99002/plo-99002 has 'I' (valid) and 'Q' (unknown) -> 1 row at scale 99001.
+    assert (99002, 99001, 99002) in rows
+    assert (99002, 99002, 99001) in rows
+    assert not any(r[0] == 99001 and r[1] == 99001 for r in rows), \
+        f"clo-99001/plo-99001 had only an unknown label; expected 0 rows. Got: {rows}"
+    assert all(r[2] in {99001, 99002} for r in rows), \
+        f"All scale_ids must be from the program's seeded scales. Got: {rows}"
+
+
+def test_idempotent_delivery_no_duplicate_rows(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """Re-delivering the same payload via the API must not duplicate outcome_map_ai_suggestions rows."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    _trigger_ai_pipeline(
+        s3_client, s3_bucket, dynamo_table, laravel_session,
+        course_id, program_id, "sample_ai_output.jsonl",
+    )
+    rows_before = sorted(_suggestions_for_clos(pg_conn, seeded_course_program["clo_ids"]))
+    assert len(rows_before) > 0, "First delivery wrote no rows; cannot validate idempotency"
+
+    # Replay the same payload directly to Laravel (bypasses FastAPI dedup; tests Laravel-side idempotency).
+    payload = {
+        "request_id": "e2e-replay",
+        "course_id":  course_id,
+        "program_id": program_id,
+        "status":     "AWAITING_COMPLETION",
+        "results": [
+            {"clo_id": 99001, "plo_id": 99001, "is_mapped": True,  "map_labels": ["I"]},
+            {"clo_id": 99001, "plo_id": 99002, "is_mapped": False, "map_labels": []},
+            {"clo_id": 99002, "plo_id": 99001, "is_mapped": True,  "map_labels": ["D"]},
+            {"clo_id": 99002, "plo_id": 99002, "is_mapped": True,  "map_labels": ["I", "D"]},
+        ],
+    }
+    r = requests.post(
+        f"{LARAVEL_URL}/api/microservices/lo-mapping/ai-suggestions/store",
+        json=payload, timeout=10,
+    )
+    assert r.status_code == 200, r.text
+
+    rows_after = sorted(_suggestions_for_clos(pg_conn, seeded_course_program["clo_ids"]))
+    assert rows_after == rows_before, (
+        f"Replay produced extra/different rows.\nBefore: {rows_before}\nAfter:  {rows_after}"
+    )
+
+
+def test_categorized_plos_render_with_icons(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """The categorized-PLO branch of step5.blade.php should render purple icons too."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+    CATEGORY_ID = 99001
+    CATEGORY_LABEL = "E2E Test Category"
+
+    cur = pg_conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO p_l_o_categories (plo_category_id, program_id, plo_category, created_at, updated_at) "
+            "VALUES (%s, %s, %s, NOW(), NOW())",
+            (CATEGORY_ID, program_id, CATEGORY_LABEL),
+        )
+        # Assign PLO 99001 to the category; leave 99002 uncategorized so both branches render.
+        cur.execute(
+            "UPDATE program_learning_outcomes SET plo_category_id = %s WHERE pl_outcome_id = 99001",
+            (CATEGORY_ID,),
+        )
+        pg_conn.commit()
+    except Exception:
+        pg_conn.rollback()
+        raise
+    finally:
+        cur.close()
+
+    _trigger_ai_pipeline(
+        s3_client, s3_bucket, dynamo_table, laravel_session,
+        course_id, program_id, "sample_ai_output.jsonl",
+    )
+
+    page = laravel_session.get(f"{LARAVEL_URL}/courseWizard/{course_id}/step5")
+    assert page.status_code == 200
+    assert CATEGORY_LABEL in page.text, "Categorized branch never rendered the category"
+    assert "Uncategorized PLOs" in page.text, "Uncategorized section is missing"
+    assert "AISuggestionPurple.png" in page.text, "No purple icons rendered for the categorized PLO"
+    # PLO 99001 is in the seeded fixture's mapped results, so its row should include at least one icon.
+    soup = BeautifulSoup(page.text, "html.parser")
+    purple_imgs = [img for img in soup.find_all("img") if "AISuggestionPurple.png" in (img.get("src") or "")]
+    assert len(purple_imgs) >= 1, f"Expected at least one purple icon, found {len(purple_imgs)}"
+
+
+def test_all_unmapped_routes_to_na_scale(
+    fastapi_service, seeded_course_program, s3_bucket, s3_client, dynamo_table, laravel_session, pg_conn,
+):
+    """When is_mapped is false for every entry, all rows route to the pre-seeded N/A scale (id=0)."""
+    course_id  = seeded_course_program["course_id"]
+    program_id = seeded_course_program["program_id"]
+
+    _trigger_ai_pipeline(
+        s3_client, s3_bucket, dynamo_table, laravel_session,
+        course_id, program_id, "all_unmapped_ai_output.jsonl",
+    )
+
+    rows = _suggestions_for_clos(pg_conn, seeded_course_program["clo_ids"])
+    assert len(rows) == 4, f"Expected 4 rows (one per CLO/PLO pair), got {len(rows)}: {rows}"
+    assert all(r[2] == 0 for r in rows), \
+        f"All rows should route to N/A scale (map_scale_id=0). Got: {rows}"

--- a/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
+++ b/python/services/lo_mapping_service/tests/e2e/test_ai_suggestions_e2e.py
@@ -3,11 +3,6 @@ End-to-end test that simulates a SageMaker job completing for a course/program,
 drives the polling endpoint, and verifies the AI-suggested mappings render on
 Step 5 with the expected purple icons.
 
-Skips:
-  - The actual SageMaker run (LocalStack does not support batch transform).
-  - The Lambda invocation chain (we directly create the AWAITING_COMPLETION
-    DynamoDB record and place dummy output in S3).
-
 Covers:
   - LocalStack DynamoDB + S3 read by FastAPI
   - FastAPI process_records pipeline
@@ -15,10 +10,17 @@ Covers:
   - Postgres outcome_map_ai_suggestions writes
   - course_programs flag updates
   - Step 5 HTML response contains purple icons in the right cells
+Limitations:
+  - Skips the actual SageMaker run (LocalStack does not support batch transform).
+  - Skips the Lambda invocation chain (we directly create the AWAITING_COMPLETION
+    DynamoDB record and place dummy output in S3).
 """
+  
 import datetime as dt
+import tempfile
 import uuid
 import time
+from pathlib import Path
 
 import pytest
 import requests
@@ -28,6 +30,7 @@ from tests.e2e.conftest import (
     LARAVEL_URL,
     DYNAMO_TABLE_NAME,
     upload_dummy_sagemaker_output,
+    get_csrf_token,
 )
 
 
@@ -77,11 +80,15 @@ def test_ai_suggestions_render_on_step5(
     # 2. Inject AWAITING_COMPLETION DynamoDB record pointing at that output
     request_id = _put_awaiting_completion_record(dynamo_table, course_id, program_id, output_uri)
 
+    # web middleware group so POSTs need X-CSRF-TOKEN.
+    csrf_token = get_csrf_token(laravel_session, f"{LARAVEL_URL}/home")
+    post_headers = {"Accept": "application/json", "X-CSRF-TOKEN": csrf_token}
+
     # 3. Drive the polling endpoint - this should pick up the record, deliver to
     #    Laravel, write rows, set the flags, and delete the DynamoDB record.
     r = laravel_session.post(
         f"{LARAVEL_URL}/courseWizard/{course_id}/{program_id}/check-ai-results",
-        headers={"Accept": "application/json"},
+        headers=post_headers,
     )
     assert r.status_code == 200, r.text
 
@@ -91,7 +98,7 @@ def test_ai_suggestions_render_on_step5(
     for _ in range(15):
         r = laravel_session.post(
             f"{LARAVEL_URL}/courseWizard/{course_id}/{program_id}/check-ai-results",
-            headers={"Accept": "application/json"},
+            headers=post_headers,
         )
         if r.json().get("status") == "complete":
             completed = True
@@ -137,11 +144,31 @@ def test_ai_suggestions_render_on_step5(
     page = laravel_session.get(f"{LARAVEL_URL}/courseWizard/{course_id}/step5")
     assert page.status_code == 200, f"Step 5 returned {page.status_code}"
 
+    # Dump rendered HTML so failed assertions below can be inspected post-mortem.
+    html_dump = Path(tempfile.gettempdir()) / f"e2e-step5-{course_id}-{program_id}.html"
+    html_dump.write_text(page.text, encoding="utf-8")
+
+    def _ctx(msg: str) -> str:
+        return f"{msg}\n  Final URL: {page.url}\n  HTML dump: {html_dump}"
+
+    # Confirm we actually landed on step5 of OUR course (no silent redirect).
+    assert page.url.rstrip("/").endswith(f"/courseWizard/{course_id}/step5"), \
+        _ctx("Did not land on step5 of the test course")
+
+    # Drill-down: prove each loop is producing content.
+    assert "E2E Test Program" in page.text, _ctx("Program iteration produced no output")
+    assert ("Test CLO 1" in page.text or "clo1" in page.text), _ctx("CLO iteration produced no output")
+    assert ("Test PLO 1" in page.text or "plo1" in page.text), _ctx("PLO iteration produced no output")
+    assert "AISuggestionPurple.png" in page.text, _ctx(
+        "Page rendered programs/CLOs/PLOs but no AI suggestion icons at all - "
+        "the aiSuggestedOutcomeMap relation isn't matching the seeded rows."
+    )
+
     soup = BeautifulSoup(page.text, "html.parser")
     purple_imgs = [
         img for img in soup.find_all("img")
         if "AISuggestionPurple.png" in (img.get("src") or "")
     ]
-    assert len(purple_imgs) >= 4, (
+    assert len(purple_imgs) >= 4, _ctx(
         f"Expected at least 4 purple icons (one per mapped scale), found {len(purple_imgs)}"
     )

--- a/python/services/lo_mapping_service/tests/test_mapping_request_repository.py
+++ b/python/services/lo_mapping_service/tests/test_mapping_request_repository.py
@@ -8,6 +8,7 @@ from app.services.lo_mapping_request_dynamo_db_request import LOMappingRequestDy
 
 TABLE_NAME = "test-lo-mapping-requests-table"
 AWS_REGION = "ca-central-1"
+OUTPUT_S3_URI = "s3://test-bucket/output/"
 
 
 @pytest.fixture(autouse=True)
@@ -17,6 +18,10 @@ def env_vars(monkeypatch):
     monkeypatch.setenv("AWS_REGION", AWS_REGION)
     monkeypatch.setenv("ACCESS_KEY", "fake-access-key")
     monkeypatch.setenv("SECRET_KEY", "fake-secret-key")
+    monkeypatch.setenv("OUTPUT_S3_URI", OUTPUT_S3_URI)
+    # Make sure a leaked AWS_ENDPOINT_URL from another test file doesn't
+    # redirect boto3 away from moto's mock.
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
 
 
 @pytest.fixture
@@ -117,7 +122,7 @@ class TestLOMappingRequestDynamoDBRecordCreateRequest:
         assert item["program_id"] == 202
         assert item["status"] == "PENDING"
         assert item["input_s3_path"] == "s3://bucket/batch_inputs/file.json"
-        assert item["output_s3_path"] == "s3://bucket/batch_outputs/file.json.out"
+        assert item["output_s3_path"] == f"{OUTPUT_S3_URI.rstrip('/')}/file.json.out"
         assert "created_at" in item
 
     @mock_aws

--- a/python/services/lo_mapping_service/tests/test_mapping_request_repository.py
+++ b/python/services/lo_mapping_service/tests/test_mapping_request_repository.py
@@ -13,7 +13,7 @@ AWS_REGION = "ca-central-1"
 @pytest.fixture(autouse=True)
 def env_vars(monkeypatch):
     """Set required environment variables for all tests."""
-    monkeypatch.setenv("LO_MAPPING_REQUESTS_TABLE", TABLE_NAME)
+    monkeypatch.setenv("LO_MAPPING_DYNAMODB_REQUESTS_TABLE", TABLE_NAME)
     monkeypatch.setenv("AWS_REGION", AWS_REGION)
     monkeypatch.setenv("ACCESS_KEY", "fake-access-key")
     monkeypatch.setenv("SECRET_KEY", "fake-secret-key")
@@ -27,7 +27,7 @@ def record():
 class TestLOMappingRequestDynamoDBRecordEnsureTableExists:
     def test_uses_pydantic_settings_object(self):
         settings = Settings(
-            LO_MAPPING_REQUESTS_TABLE="custom-table",
+            LO_MAPPING_DYNAMODB_REQUESTS_TABLE="custom-table",
             AWS_REGION=AWS_REGION,
             ACCESS_KEY="custom-access-key",
             SECRET_KEY="custom-secret-key",
@@ -44,7 +44,7 @@ class TestLOMappingRequestDynamoDBRecordEnsureTableExists:
 
     def test_raises_if_table_name_not_set(self, record):
         record.table_name = None
-        with pytest.raises(ValueError, match="LO_MAPPING_REQUESTS_TABLE is not set"):
+        with pytest.raises(ValueError, match="LO_MAPPING_DYNAMODB_REQUESTS_TABLE is not set"):
             record.ensure_table_exists()
 
     @mock_aws
@@ -92,7 +92,7 @@ class TestLOMappingRequestDynamoDBRecordCreateRequest:
 
     def test_raises_if_table_name_not_set(self, record):
         record.table_name = None
-        with pytest.raises(ValueError, match="LO_MAPPING_REQUESTS_TABLE is not set"):
+        with pytest.raises(ValueError, match="LO_MAPPING_DYNAMODB_REQUESTS_TABLE is not set"):
             record.create_request(1, 2, "s3://bucket/batch_inputs/file.json")
 
     def test_raises_if_input_s3_path_empty(self, record):


### PR DESCRIPTION
Ticks off leftover items from PR #8

- Integrated AWS Lambda with Laravel backend
- Set up on-demand pull of SageMaker output from DynamoDB in the frontend.
    - When the page loads, it attempts to fetch any AI suggestions for that PLO-CLO pairs that weren't fetched yet. It keeps polling for 10 minutes - if the user stays on the page for 10 minutes, it stops polling and shows a refresh button which restarts the polling. If the suggestions are available, they're pulled, stored in the postgresql database, and the page is reloaded to display the suggestions. 
   - If SageMaker has is_mapped: false for a certain PLO-CLO pair, then it is mapped to the column labelled "N/A"
- Bug fixes
- Added localstack e2e tests for the lo mapping service. They don't test SageMaker itself, but do test the frontend and laravel portions of the flow. These run with the moto unit tests with `pytest -v -s`. Details on running tests found in `lo_mapping_service/tests/e2e/README.md`


Note: the frontend is sometimes janky or buggy with modals due to the Bootstrap versioning issue, but should be good once we sort that out