### PR TITLE
Kabir/search results export

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -174,7 +174,7 @@ After a search returns results, the page displays a **Download PDF** button. The
 
 Course view exports use `search.exports.course-results` and list courses with their related programs, match counts, and all matching snippets. Program view exports use `search.exports.program-results` and group matching courses and snippets under each program. Material Content matches include the source filename and page number in both exports.
 
-The response downloads as either `course-search-results-YYYY-MM-DD.pdf` or `program-search-results-YYYY-MM-DD.pdf`.
+The response filename includes a safe, shortened version of the query, such as `climate-change-course-search-results-YYYY-MM-DD.pdf` or `climate-change-program-search-results-YYYY-MM-DD.pdf`.
 
 ## Saved Filter Presets
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -12,6 +12,8 @@ This feature is implemented primarily under:
 - [`laravel/app/Http/Controllers/SavedSearchFilterController.php`](../laravel/app/Http/Controllers/SavedSearchFilterController.php)
 - [`laravel/app/Helpers/SearchFilterOptions.php`](../laravel/app/Helpers/SearchFilterOptions.php)
 - [`laravel/resources/views/search/index.blade.php`](../laravel/resources/views/search/index.blade.php)
+- [`laravel/resources/views/search/exports/course-results.blade.php`](../laravel/resources/views/search/exports/course-results.blade.php)
+- [`laravel/resources/views/search/exports/program-results.blade.php`](../laravel/resources/views/search/exports/program-results.blade.php)
 - [`laravel/resources/views/search/partials/highlighted-snippet.blade.php`](../laravel/resources/views/search/partials/highlighted-snippet.blade.php)
 - [`laravel/resources/views/search/partials/result-match.blade.php`](../laravel/resources/views/search/partials/result-match.blade.php)
 - [`laravel/tests/Feature/SearchTest.php`](../laravel/tests/Feature/SearchTest.php)
@@ -32,6 +34,7 @@ The feature is responsible for:
 - searching program names
 - filtering results by course code, course level, program, and searchable property
 - showing results in either Course view or Program view
+- exporting Course view and Program view results as PDF files
 - saving, applying, and deleting user-specific search filter presets
 
 ## Routes
@@ -40,7 +43,10 @@ The main search page is:
 
 ```php
 GET /search
+GET /search/export/pdf
 ```
+
+The PDF route exports the current search query, selected view, and filters.
 
 The saved filter preset routes are:
 
@@ -162,6 +168,14 @@ Program view groups matching courses under their programs. Program results can c
 
 Material Content matches also show the source PDF filename and page number. The source link opens the uploaded PDF at the matching page in a new tab.
 
+## PDF Export
+
+After a search returns results, the page displays a **Download PDF** button. The export preserves the current query, result view, property filters, course filters, and program filters. Pagination is not included, so the PDF contains the complete matching result collection instead of only the current page.
+
+Course view exports use `search.exports.course-results` and list courses with their related programs, match counts, and all matching snippets. Program view exports use `search.exports.program-results` and group matching courses and snippets under each program. Material Content matches include the source filename and page number in both exports.
+
+The response downloads as either `course-search-results-YYYY-MM-DD.pdf` or `program-search-results-YYYY-MM-DD.pdf`.
+
 ## Saved Filter Presets
 
 Authenticated users can save named filter presets.
@@ -227,6 +241,7 @@ The tests cover:
 - search stats
 - course and program pagination
 - course code, course level, and program filters
+- Course view and Program view PDF exports
 - saved filter saving, applying, deleting, ownership restrictions, and current preset display
 
 Run the search tests with:
@@ -245,5 +260,6 @@ Few constraints that might be important to consider for this feature:
 - search result links go to existing course and program wizard routes
 - only files with an `INDEXED` status are included in Material Content searches
 - PHP-side grouping and pagination is fine for a small dataset, but may need refactoring if the database grows extremely large, which is unlikely
+- PDF exports render all matching results through Dompdf, so very broad searches may need to be narrowed if they exceed the server's available memory
 - empty-query listing is not currently implemented
 - if new searchable fields are added, update `SearchFilterOptions`, migrations, controller search methods, tests, and this doc

--- a/laravel/app/Http/Controllers/CourseController.php
+++ b/laravel/app/Http/Controllers/CourseController.php
@@ -784,10 +784,11 @@ class CourseController extends Controller
             $pdf = PDF::loadView('courses.downloadSummary', compact('course', 'courseLearningOutcomes', 'programsLearningOutcomes', 'unCategorizedProgramsLearningOutcomes', 'programsMappingScales', 'outcomeActivities', 'outcomeAssessments', 'courseStandardOutcomes', 'courseStandardScales', 'standardOutcomeMap', 'assessmentMethodsTotal', 'courseProgramsOutcomeMaps', 'optionalSubcategories'));
             // get the content of the pdf document
             $content = $pdf->output();
+            $pdfPath = 'course-'.$course->course_id.'.pdf';
             // store the pdf document in storage/app/public folder
-            Storage::put('public/course-'.$course->course_id.'.pdf', $content);
+            Storage::disk('public')->put($pdfPath, $content);
             // get the url of the document
-            $url = Storage::url('course-'.$course->course_id.'.pdf');
+            $url = Storage::disk('public')->url($pdfPath);
 
             // return the location of the pdf document on the server
             return $url;
@@ -807,7 +808,7 @@ class CourseController extends Controller
 
     public function deletePDF(Request $request, $course_id)
     {
-        Storage::delete('public/course-'.$course_id.'.pdf');
+        Storage::disk('public')->delete('course-'.$course_id.'.pdf');
     }
 
     // Method for generating data excel in course level
@@ -933,13 +934,13 @@ class CourseController extends Controller
             // generate the spreadsheet
             $writer = new Xlsx($spreadsheet);
             // set the spreadsheets name
-            $spreadsheetName = 'data-summary-'.$course->course_title.'.xlsx';
-            // create absolute filename
-            $storagePath = storage_path('app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'spreadsheets'.DIRECTORY_SEPARATOR.$spreadsheetName);
+            $spreadsheetName = 'data-summary-course-'.$course->course_id.'.xlsx';
+            $spreadsheetPath = 'spreadsheets/'.$spreadsheetName;
+            Storage::disk('public')->makeDirectory('spreadsheets');
             // save the spreadsheet document
-            $writer->save($storagePath);
+            $writer->save(Storage::disk('public')->path($spreadsheetPath));
             // get the url of the document
-            $url = Storage::url('spreadsheets'.DIRECTORY_SEPARATOR.$spreadsheetName);
+            $url = Storage::disk('public')->url($spreadsheetPath);
 
             // return the location of the spreadsheet document on the server
             return $url;
@@ -954,6 +955,11 @@ class CourseController extends Controller
 
             return -1;
         }
+    }
+
+    public function deleteDataSpreadsheet(Request $request, $course_id)
+    {
+        Storage::disk('public')->delete('spreadsheets/data-summary-course-'.$course_id.'.xlsx');
     }
 
 

--- a/laravel/app/Http/Controllers/CourseController.php
+++ b/laravel/app/Http/Controllers/CourseController.php
@@ -69,7 +69,7 @@ class CourseController extends Controller
     public function __construct()
     {
         $this->middleware(['auth', 'verified']);
-        $this->middleware('course')->only(['show', 'pdf', 'edit', 'submit', 'outcomeDetails']);
+        $this->middleware('course')->only(['show', 'pdf', 'dataSpreadsheet', 'deletePDF', 'deleteDataSpreadsheet', 'edit', 'submit', 'outcomeDetails']);
         $this->roleAssignmentHelper = new RoleAssignmentHelpers();
     }
 

--- a/laravel/app/Http/Controllers/ProgramController.php
+++ b/laravel/app/Http/Controllers/ProgramController.php
@@ -962,12 +962,13 @@ class ProgramController extends Controller
             $content = $pdf->output();
             // set name of pdf
             $pdfName = 'summary-'.$program->program_id.'.pdf';
+            $pdfPath = 'pdfs/'.$pdfName;
             // store the pdf document in storage/app/public folder
-            Storage::put('public'.DIRECTORY_SEPARATOR.'pdfs'.DIRECTORY_SEPARATOR.$pdfName, $content);
+            Storage::disk('public')->put($pdfPath, $content);
             // delete charts
             $this->deleteCharts($program_id, $charts);
             // get the url of the document
-            $url = Storage::url('pdfs'.DIRECTORY_SEPARATOR.$pdfName);
+            $url = Storage::disk('public')->url($pdfPath);
 
             // return the location of the pdf document on the server
             return $url;
@@ -993,7 +994,7 @@ class ProgramController extends Controller
      */
     public function deletePDF(Request $request, $program_id)
     {
-        Storage::delete('public/program-'.$program_id.'.pdf');
+        Storage::disk('public')->delete('pdfs/summary-'.$program_id.'.pdf');
     }
 
     /**
@@ -1052,14 +1053,14 @@ class ProgramController extends Controller
             $writer = new Xlsx($spreadsheet);
             // set the spreadsheets name
             $spreadsheetName = 'summary-'.$program->program_id.'.xlsx';
-            // create absolute filename
-            $storagePath = storage_path('app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'spreadsheets'.DIRECTORY_SEPARATOR.$spreadsheetName);
+            $spreadsheetPath = 'spreadsheets/'.$spreadsheetName;
+            Storage::disk('public')->makeDirectory('spreadsheets');
             // save the spreadsheet document
-            $writer->save($storagePath);
+            $writer->save(Storage::disk('public')->path($spreadsheetPath));
             // delete charts
             $this->deleteCharts($programId, $charts);
             // get the url of the document
-            $url = Storage::url('spreadsheets'.DIRECTORY_SEPARATOR.$spreadsheetName);
+            $url = Storage::disk('public')->url($spreadsheetPath);
 
             // return the location of the spreadsheet document on the server
             return $url;
@@ -1141,13 +1142,13 @@ class ProgramController extends Controller
             // generate the spreadsheet
             $writer = new Xlsx($spreadsheet);
             // set the spreadsheets name
-            $spreadsheetName = 'data-summary-'.$program->program.'.xlsx';
-            // create absolute filename
-            $storagePath = storage_path('app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'spreadsheets'.DIRECTORY_SEPARATOR.$spreadsheetName);
+            $spreadsheetName = 'data-summary-program-'.$program->program_id.'.xlsx';
+            $spreadsheetPath = 'spreadsheets/'.$spreadsheetName;
+            Storage::disk('public')->makeDirectory('spreadsheets');
             // save the spreadsheet document
-            $writer->save($storagePath);
+            $writer->save(Storage::disk('public')->path($spreadsheetPath));
             // get the url of the document
-            $url = Storage::url('spreadsheets'.DIRECTORY_SEPARATOR.$spreadsheetName);
+            $url = Storage::disk('public')->url($spreadsheetPath);
 
             // return the location of the spreadsheet document on the server
             return $url;
@@ -2574,7 +2575,7 @@ class ProgramController extends Controller
     {
         try {
             $program = Program::find($programId);
-            Storage::delete('public/program-'.$program->program_id.'.xlsx');
+            Storage::disk('public')->delete('spreadsheets/summary-'.$program->program_id.'.xlsx');
         } catch (Throwable $exception) {
             $message = 'There was an error deleting the saved spreadsheet overview for: '.$program->program;
             Log::error($message.' ...\n');
@@ -2583,6 +2584,11 @@ class ProgramController extends Controller
             Log::error('Line - '.$exception->getLine());
             Log::error($exception->getMessage());
         }
+    }
+
+    public function deleteDataSpreadsheet(Request $request, int $programId)
+    {
+        Storage::disk('public')->delete('spreadsheets/data-summary-program-'.$programId.'.xlsx');
     }
 
     public function resetKeysSingle($array)

--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Builder; //Builder is for a DB query that is still being constructed
+use PDF;
 
 class SearchController extends Controller
 
@@ -174,6 +175,109 @@ class SearchController extends Controller
         ]);
         
 }
+
+    /**
+     * Downloads all matching Course View results as a PDF.
+     *
+     * @param Request $request The incoming request containing the search query and selected filters.
+     *
+     * @return \Illuminate\Http\Response The generated PDF download response.
+     */
+    public function exportPdf(Request $request)
+    {
+        $filters = $this->getCourseExportFilters($request);
+        $searchData = $this->buildSearchResults(
+            $filters['searchTerm'],
+            'courses',
+            $filters['selectedProperties'],
+            $filters['selectedCourseCodes'],
+            $filters['selectedCourseLevels'],
+            $filters['selectedProgramIds'],
+        );
+
+        $selectedProgramNames = DB::table('programs')
+            ->whereIn('program_id', $filters['selectedProgramIds'])
+            ->orderBy('program')
+            ->pluck('program')
+            ->all();
+
+        $filterSummary = [
+            'Properties' => collect($filters['selectedProperties'])
+                ->map(fn ($property) => SearchFilterOptions::properties()[$property] ?? $property)
+                ->implode(', ') ?: 'None',
+            'Course Codes' => implode(', ', $filters['selectedCourseCodes']) ?: 'All',
+            'Course Levels' => implode(', ', $filters['selectedCourseLevels']) ?: 'All',
+            'Programs' => empty($filters['selectedProgramIds'])
+                ? 'All'
+                : (implode(', ', $selectedProgramNames) ?: 'Selected programs unavailable'),
+        ];
+
+        return PDF::loadView('search.exports.course-results', [
+            'searchTerm' => $filters['searchTerm'],
+            'results' => $searchData['results'],
+            'filterSummary' => $filterSummary,
+        ])->download('course-search-results-'.now()->format('Y-m-d').'.pdf');
+    }
+
+    /**
+     * Validates and normalizes the filters used by Course View exports.
+     *
+     * @param Request $request The incoming request containing the search query and selected filters.
+     *
+     * @return array The normalized query, property filters, course filters, and program filters.
+     */
+    private function getCourseExportFilters(Request $request): array
+    {
+        $validated = $request->validate([
+            'query' => ['required', 'string', 'max:200', 'regex:/\S/'],
+            'view' => ['nullable', 'in:courses'],
+            'property_filters_applied' => ['nullable', 'boolean'],
+            'properties' => ['nullable', 'array'],
+            'properties.*' => [SearchFilterOptions::propertyValidationRule()],
+            'course_filters_applied' => ['nullable', 'boolean'],
+            'course_codes' => ['nullable', 'array'],
+            'course_codes.*' => ['nullable', 'string', 'max:10'],
+            'course_levels' => ['nullable', 'array'],
+            'course_levels.*' => ['nullable', 'in:100,200,300,400,500,600'],
+            'program_filters_applied' => ['nullable', 'boolean'],
+            'program_ids' => ['nullable', 'array'],
+            'program_ids.*' => ['nullable', 'integer'],
+        ]);
+
+        $propertyFiltersApplied = (bool) ($validated['property_filters_applied'] ?? false);
+        $courseFiltersApplied = (bool) ($validated['course_filters_applied'] ?? false);
+        $programFiltersApplied = (bool) ($validated['program_filters_applied'] ?? false);
+
+        return [
+            'searchTerm' => preg_replace('/\s+/', ' ', trim($validated['query'])),
+            'selectedProperties' => $propertyFiltersApplied
+                ? ($validated['properties'] ?? [])
+                : SearchFilterOptions::propertyKeys(),
+            'selectedCourseCodes' => $courseFiltersApplied
+                ? collect($validated['course_codes'] ?? [])
+                    ->filter(fn ($code) => is_string($code) && trim($code) !== '')
+                    ->map(fn ($code) => strtoupper(trim($code)))
+                    ->unique()
+                    ->values()
+                    ->all()
+                : [],
+            'selectedCourseLevels' => $courseFiltersApplied
+                ? collect($validated['course_levels'] ?? [])
+                    ->filter(fn ($level) => is_string($level) && trim($level) !== '')
+                    ->unique()
+                    ->values()
+                    ->all()
+                : [],
+            'selectedProgramIds' => $programFiltersApplied
+                ? collect($validated['program_ids'] ?? [])
+                    ->filter(fn ($programId) => is_numeric($programId))
+                    ->map(fn ($programId) => (int) $programId)
+                    ->unique()
+                    ->values()
+                    ->all()
+                : [],
+        ];
+    }
 
     /**
      * Builds the complete course or program result collection before pagination is applied.

--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -126,40 +126,20 @@ class SearchController extends Controller
         $searchPerformed = $searchTerm !== '' && ! $presetApplied;
 
         if($searchPerformed){
-            $resultsAndStats = $this->searchCourses(
+            $searchData = $this->buildSearchResults(
                 $searchTerm,
+                $selectedView,
                 $selectedProperties,
                 $selectedCourseCodes,
                 $selectedCourseLevels,
                 $selectedProgramIds,
             );
-            $results = $resultsAndStats['results'];
-            $stats = $resultsAndStats['stats'];
-            $courseQuickLinks = $results;
-            $programQuickLinks = $results
-                ->flatMap(fn ($course) => $course->programs)
-                ->unique('program_id')
-                ->values();
-
-            if ($selectedView === 'programs') {
-                $programMatches = $this->searchProgramNames($searchTerm, $selectedCourseCodes, $selectedCourseLevels);
-                $programResults = $this->groupCourseResultsByProgram($results, $programMatches, $selectedProgramIds);
-                $stats['programs'] = $programResults->count();
-                $programQuickLinks = $programResults;
-
-                $stats['courses'] = $programResults
-                    ->flatMap(fn ($program) => $program->courses)
-                    ->pluck('course_id')
-                    ->unique()
-                    ->count();
-                    //for the program view, only courses assigned to a program are counted in the statistics
-
-                $courseQuickLinks = $programResults
-                    ->flatMap(fn ($program) => $program->courses)
-                    ->unique('course_id')
-                    ->values();
-            }
-
+            $results = $searchData['results'];
+            $programMatches = $searchData['programMatches'];
+            $programResults = $searchData['programResults'];
+            $courseQuickLinks = $searchData['courseQuickLinks'];
+            $programQuickLinks = $searchData['programQuickLinks'];
+            $stats = $searchData['stats'];
         }
 
         $results = $this->paginateResults($results, $request); //handle many restults via pagination
@@ -194,6 +174,72 @@ class SearchController extends Controller
         ]);
         
 }
+
+    /**
+     * Builds the complete course or program result collection before pagination is applied.
+     *
+     * @param string $searchTerm The normalized text to search for.
+     * @param string $selectedView The selected course or program result view.
+     * @param array $selectedProperties The course properties included in the search.
+     * @param array $selectedCourseCodes The course codes included in the search.
+     * @param array $selectedCourseLevels The course number levels included in the search.
+     * @param array $selectedProgramIds The program IDs included in the search.
+     *
+     * @return array The unpaginated results, statistics, and quick-link collections.
+     */
+    private function buildSearchResults(
+        string $searchTerm,
+        string $selectedView,
+        array $selectedProperties,
+        array $selectedCourseCodes,
+        array $selectedCourseLevels,
+        array $selectedProgramIds,
+    ): array {
+        $resultsAndStats = $this->searchCourses(
+            $searchTerm,
+            $selectedProperties,
+            $selectedCourseCodes,
+            $selectedCourseLevels,
+            $selectedProgramIds,
+        );
+        $results = $resultsAndStats['results'];
+        $stats = $resultsAndStats['stats'];
+        $programMatches = collect();
+        $programResults = collect();
+        $courseQuickLinks = $results;
+        $programQuickLinks = $results
+            ->flatMap(fn ($course) => $course->programs)
+            ->unique('program_id')
+            ->values();
+
+        if ($selectedView === 'programs') {
+            $programMatches = $this->searchProgramNames($searchTerm, $selectedCourseCodes, $selectedCourseLevels);
+            $programResults = $this->groupCourseResultsByProgram($results, $programMatches, $selectedProgramIds);
+            $stats['programs'] = $programResults->count();
+            $programQuickLinks = $programResults;
+
+            $stats['courses'] = $programResults
+                ->flatMap(fn ($program) => $program->courses)
+                ->pluck('course_id')
+                ->unique()
+                ->count();
+                //for the program view, only courses assigned to a program are counted in the statistics
+
+            $courseQuickLinks = $programResults
+                ->flatMap(fn ($program) => $program->courses)
+                ->unique('course_id')
+                ->values();
+        }
+
+        return [
+            'results' => $results,
+            'programMatches' => $programMatches,
+            'programResults' => $programResults,
+            'courseQuickLinks' => $courseQuickLinks,
+            'programQuickLinks' => $programQuickLinks,
+            'stats' => $stats,
+        ];
+    }
 
     /**
      * searches the selected course properties (if selected) and prepares combined results and statistics

--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -6,6 +6,7 @@ use App\Helpers\SearchFilterOptions;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Query\Builder; //Builder is for a DB query that is still being constructed
 use PDF;
@@ -211,20 +212,21 @@ class SearchController extends Controller
                 ? 'All'
                 : (implode(', ', $selectedProgramNames) ?: 'Selected programs unavailable'),
         ];
+        $querySlug = trim(Str::limit(Str::slug($filters['searchTerm']), 50, ''), '-') ?: 'filtered';
 
         if ($filters['selectedView'] === 'programs') {
             return PDF::loadView('search.exports.program-results', [
                 'searchTerm' => $filters['searchTerm'],
                 'programResults' => $searchData['programResults'],
                 'filterSummary' => $filterSummary,
-            ])->download('program-search-results-'.now()->format('Y-m-d').'.pdf');
+            ])->download($querySlug.'-program-search-results-'.now()->format('Y-m-d').'.pdf');
         }
 
         return PDF::loadView('search.exports.course-results', [
             'searchTerm' => $filters['searchTerm'],
             'results' => $searchData['results'],
             'filterSummary' => $filterSummary,
-        ])->download('course-search-results-'.now()->format('Y-m-d').'.pdf');
+        ])->download($querySlug.'-course-search-results-'.now()->format('Y-m-d').'.pdf');
     }
 
     /**

--- a/laravel/app/Http/Controllers/SearchController.php
+++ b/laravel/app/Http/Controllers/SearchController.php
@@ -177,7 +177,7 @@ class SearchController extends Controller
 }
 
     /**
-     * Downloads all matching Course View results as a PDF.
+     * Downloads all matching Course View or Program View results as a PDF.
      *
      * @param Request $request The incoming request containing the search query and selected filters.
      *
@@ -185,10 +185,10 @@ class SearchController extends Controller
      */
     public function exportPdf(Request $request)
     {
-        $filters = $this->getCourseExportFilters($request);
+        $filters = $this->getExportFilters($request);
         $searchData = $this->buildSearchResults(
             $filters['searchTerm'],
-            'courses',
+            $filters['selectedView'],
             $filters['selectedProperties'],
             $filters['selectedCourseCodes'],
             $filters['selectedCourseLevels'],
@@ -212,6 +212,14 @@ class SearchController extends Controller
                 : (implode(', ', $selectedProgramNames) ?: 'Selected programs unavailable'),
         ];
 
+        if ($filters['selectedView'] === 'programs') {
+            return PDF::loadView('search.exports.program-results', [
+                'searchTerm' => $filters['searchTerm'],
+                'programResults' => $searchData['programResults'],
+                'filterSummary' => $filterSummary,
+            ])->download('program-search-results-'.now()->format('Y-m-d').'.pdf');
+        }
+
         return PDF::loadView('search.exports.course-results', [
             'searchTerm' => $filters['searchTerm'],
             'results' => $searchData['results'],
@@ -220,17 +228,17 @@ class SearchController extends Controller
     }
 
     /**
-     * Validates and normalizes the filters used by Course View exports.
+     * Validates and normalizes the filters used by search result exports.
      *
      * @param Request $request The incoming request containing the search query and selected filters.
      *
      * @return array The normalized query, property filters, course filters, and program filters.
      */
-    private function getCourseExportFilters(Request $request): array
+    private function getExportFilters(Request $request): array
     {
         $validated = $request->validate([
             'query' => ['required', 'string', 'max:200', 'regex:/\S/'],
-            'view' => ['nullable', 'in:courses'],
+            'view' => ['nullable', 'in:courses,programs'],
             'property_filters_applied' => ['nullable', 'boolean'],
             'properties' => ['nullable', 'array'],
             'properties.*' => [SearchFilterOptions::propertyValidationRule()],
@@ -250,6 +258,7 @@ class SearchController extends Controller
 
         return [
             'searchTerm' => preg_replace('/\s+/', ' ', trim($validated['query'])),
+            'selectedView' => $validated['view'] ?? 'courses',
             'selectedProperties' => $propertyFiltersApplied
                 ? ($validated['properties'] ?? [])
                 : SearchFilterOptions::propertyKeys(),

--- a/laravel/config/filesystems.php
+++ b/laravel/config/filesystems.php
@@ -72,7 +72,7 @@ return [
     */
 
     'links' => [
-        public_path('storage') => storage_path('app\\public'),
+        public_path('storage') => storage_path('app/public'),
     ],
 
 ];

--- a/laravel/resources/views/search/exports/course-results.blade.php
+++ b/laravel/resources/views/search/exports/course-results.blade.php
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {
+                color: #002145;
+                font-family: DejaVu Sans, sans-serif;
+                font-size: 10px;
+                line-height: 1.4;
+            }
+
+            h1 {
+                font-size: 20px;
+                margin: 0 0 4px;
+            }
+
+            h2 {
+                font-size: 13px;
+                margin: 0 0 4px;
+            }
+
+            .generated {
+                color: #555;
+                margin-bottom: 14px;
+            }
+
+            .summary {
+                border-collapse: collapse;
+                margin-bottom: 18px;
+                width: 100%;
+            }
+
+            .summary th,
+            .summary td {
+                border: 1px solid #c8d0d9;
+                padding: 5px 7px;
+                text-align: left;
+                vertical-align: top;
+            }
+
+            .summary th {
+                background: #e9ecef;
+                width: 20%;
+            }
+
+            .result {
+                border-bottom: 1px solid #c8d0d9;
+                margin-bottom: 12px;
+                padding-bottom: 10px;
+                page-break-inside: avoid;
+            }
+
+            .programs,
+            .match-counts {
+                color: #555;
+                margin: 3px 0;
+            }
+
+            .match {
+                margin: 6px 0 0 12px;
+            }
+
+            mark {
+                background: #fff3a6;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Course Search Results</h1>
+        <div class="generated">Generated {{ now()->format('Y-m-d H:i') }}</div>
+
+        <table class="summary">
+            <tr>
+                <th>Search Query</th>
+                <td>{{ $searchTerm }}</td>
+            </tr>
+            @foreach($filterSummary as $label => $value)
+                <tr>
+                    <th>{{ $label }}</th>
+                    <td>{{ $value }}</td>
+                </tr>
+            @endforeach
+            <tr>
+                <th>Results</th>
+                <td>{{ $results->count() }}</td>
+            </tr>
+        </table>
+
+        @forelse($results as $result)
+            <div class="result">
+                <h2>{{ $result->course_code }} {{ $result->course_num }}: {{ $result->course_title }}</h2>
+
+                <div class="programs">
+                    <strong>Programs:</strong>
+                    {{ $result->programs->pluck('program')->implode(', ') ?: 'None' }}
+                </div>
+
+                <div class="match-counts">
+                    <strong>Found in:</strong>
+                    @if($result->is_course_match) Course Identity: 1; @endif
+                    @foreach([
+                        'topics' => 'Topics',
+                        'learning_outcomes' => 'Learning Objectives',
+                        'assessments' => 'Assessments',
+                        'descriptions' => 'Descriptions',
+                        'materials' => 'Materials',
+                        'material_content' => 'Material Content',
+                    ] as $key => $label)
+                        @if($result->match_stats[$key] > 0)
+                            {{ $label }}: {{ $result->match_stats[$key] }};
+                        @endif
+                    @endforeach
+                </div>
+
+                @foreach($result->matches as $match)
+                    <div class="match">
+                        <strong>{{ $match->property === 'learning outcome' ? 'Learning Objective' : ucwords($match->property) }}:</strong>
+                        @if($match->property === 'material content')
+                            {{ $match->file_name }}, Page {{ $match->page_number }}<br>
+                        @endif
+                        @include('search.partials.highlighted-snippet', ['snippet' => $match->snippet])
+                    </div>
+                @endforeach
+            </div>
+        @empty
+            <p>No matching courses were found.</p>
+        @endforelse
+    </body>
+</html>

--- a/laravel/resources/views/search/exports/program-results.blade.php
+++ b/laravel/resources/views/search/exports/program-results.blade.php
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {
+                color: #002145;
+                font-family: DejaVu Sans, sans-serif;
+                font-size: 10px;
+                line-height: 1.4;
+            }
+
+            h1 {
+                font-size: 20px;
+                margin: 0 0 4px;
+            }
+
+            h2 {
+                font-size: 14px;
+                margin: 0 0 4px;
+            }
+
+            h3 {
+                font-size: 12px;
+                margin: 8px 0 3px;
+            }
+
+            .generated {
+                color: #555;
+                margin-bottom: 14px;
+            }
+
+            .summary {
+                border-collapse: collapse;
+                margin-bottom: 18px;
+                width: 100%;
+            }
+
+            .summary th,
+            .summary td {
+                border: 1px solid #c8d0d9;
+                padding: 5px 7px;
+                text-align: left;
+                vertical-align: top;
+            }
+
+            .summary th {
+                background: #e9ecef;
+                width: 20%;
+            }
+
+            .program {
+                border-bottom: 1px solid #c8d0d9;
+                margin-bottom: 14px;
+                padding-bottom: 10px;
+            }
+
+            .course {
+                margin-left: 12px;
+                page-break-inside: avoid;
+            }
+
+            .program-match,
+            .match-counts {
+                color: #555;
+                margin: 3px 0;
+            }
+
+            .match {
+                margin: 5px 0 0 12px;
+            }
+
+            mark {
+                background: #fff3a6;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Program Search Results</h1>
+        <div class="generated">Generated {{ now()->format('Y-m-d H:i') }}</div>
+
+        <table class="summary">
+            <tr>
+                <th>Search Query</th>
+                <td>{{ $searchTerm }}</td>
+            </tr>
+            @foreach($filterSummary as $label => $value)
+                <tr>
+                    <th>{{ $label }}</th>
+                    <td>{{ $value }}</td>
+                </tr>
+            @endforeach
+            <tr>
+                <th>Programs</th>
+                <td>{{ $programResults->count() }}</td>
+            </tr>
+            <tr>
+                <th>Courses</th>
+                <td>{{ $programResults->flatMap(fn ($program) => $program->courses)->unique('course_id')->count() }}</td>
+            </tr>
+        </table>
+
+        @forelse($programResults as $programResult)
+            <div class="program">
+                <h2>{{ $programResult->program }}</h2>
+
+                @if($programResult->program_match_snippet)
+                    <div class="program-match">
+                        <strong>Program name match:</strong>
+                        @include('search.partials.highlighted-snippet', ['snippet' => $programResult->program_match_snippet])
+                    </div>
+                @endif
+
+                <div class="program-match">
+                    <strong>Matching courses:</strong> {{ $programResult->courses->count() }}
+                </div>
+
+                @forelse($programResult->courses as $course)
+                    <div class="course">
+                        <h3>{{ $course->course_code }} {{ $course->course_num }}: {{ $course->course_title }}</h3>
+
+                        <div class="match-counts">
+                            <strong>Found in:</strong>
+                            @if($course->is_course_match) Course Identity: 1; @endif
+                            @foreach([
+                                'topics' => 'Topics',
+                                'learning_outcomes' => 'Learning Objectives',
+                                'assessments' => 'Assessments',
+                                'descriptions' => 'Descriptions',
+                                'materials' => 'Materials',
+                                'material_content' => 'Material Content',
+                            ] as $key => $label)
+                                @if($course->match_stats[$key] > 0)
+                                    {{ $label }}: {{ $course->match_stats[$key] }};
+                                @endif
+                            @endforeach
+                        </div>
+
+                        @foreach($course->matches as $match)
+                            <div class="match">
+                                <strong>{{ $match->property === 'learning outcome' ? 'Learning Objective' : ucwords($match->property) }}:</strong>
+                                @if($match->property === 'material content')
+                                    {{ $match->file_name }}, Page {{ $match->page_number }}<br>
+                                @endif
+                                @include('search.partials.highlighted-snippet', ['snippet' => $match->snippet])
+                            </div>
+                        @endforeach
+                    </div>
+                @empty
+                    <p>No course content matches were found in this program.</p>
+                @endforelse
+            </div>
+        @empty
+            <p>No matching programs were found.</p>
+        @endforelse
+    </body>
+</html>

--- a/laravel/resources/views/search/index.blade.php
+++ b/laravel/resources/views/search/index.blade.php
@@ -801,6 +801,19 @@
         <p class="text-center">No matches found.</p>
     @endif
 
+    @if($searchPerformed && $hasSelectedResults)
+        <div class="text-end mb-2">
+            <a
+                href="{{ route('search.export.pdf', request()->except('page')) }}"
+                class="btn btn-outline-primary btn-sm"
+                title="Download all matching results as a PDF"
+            >
+                <i class="bi bi-file-earmark-pdf me-1"></i>
+                Download PDF
+            </a>
+        </div>
+    @endif
+
     @if($selectedView === 'courses')
         @foreach($results as $result)
             <div class="border-bottom py-3">

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -265,6 +265,9 @@ Route::get('/courseWizard/{course}/step10', [CourseWizardController::class, 'ste
 Route::get('/search', [SearchController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('search.index');
+Route::get('/search/export/pdf', [SearchController::class, 'exportPdf'])
+    ->middleware(['auth', 'verified'])
+    ->name('search.export.pdf');
 
 
 

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -127,6 +127,7 @@ Route::get('/programs/{program}/downloadUserGuide', [ProgramController::class, '
 
 // Program Summary raw data spreadsheet routes
 Route::get('/programs/{program}/dataSpreadsheet', [ProgramController::class, 'dataSpreadsheet'])->name('programs.dataSpreadsheet');
+Route::delete('/programs/{program}/dataSpreadsheet', [ProgramController::class, 'deleteDataSpreadsheet'])->name('programs.delete.dataSpreadsheet');
 
 Route::get('/programs/{program}/duplicate', [ProgramController::class, 'duplicate'])->name('programs.duplicate');
 
@@ -149,6 +150,7 @@ Route::get('/courses/{course}/pdf', [CourseController::class, 'pdf'])->name('cou
 
 // Route for spreadsheet download in course
 Route::get('/courses/{course}/dataSpreadsheet', [CourseController::class, 'dataSpreadsheet'])->name('courses.dataSpreadsheet');
+Route::delete('/courses/{course}/dataSpreadsheet', [CourseController::class, 'deleteDataSpreadsheet'])->name('courses.delete.dataSpreadsheet');
 
 Route::delete('/courses/{course}/pdf', [CourseController::class, 'deletePDF'])->name('courses.delete.pdf');
 Route::get('/courses/{course}/remove', [CourseController::class, 'removeFromProgram'])->name('courses.remove');

--- a/laravel/tests/Feature/CourseExportTest.php
+++ b/laravel/tests/Feature/CourseExportTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Course;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use Tests\TestCase;
+
+class CourseExportTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('public');
+    }
+
+    public function test_course_exports_generate_valid_files(): void
+    {
+        $user = User::factory()->create();
+        $course = $this->createAccessibleCourse($user);
+
+        $pdfPath = 'course-'.$course->course_id.'.pdf';
+        $spreadsheetPath = 'spreadsheets/data-summary-course-'.$course->course_id.'.xlsx';
+
+        $this->actingAs($user)->get(route('courses.pdf', $course->course_id))->assertOk();
+
+        Storage::disk('public')->assertExists($pdfPath);
+        $this->assertStringStartsWith('%PDF', Storage::disk('public')->get($pdfPath));
+        $this->assertDirectoryDoesNotExist(Storage::disk('public')->path('spreadsheets'));
+
+        $this->get(route('courses.dataSpreadsheet', $course->course_id))->assertOk();
+
+        Storage::disk('public')->assertExists($spreadsheetPath);
+        $this->assertSame('Xlsx', IOFactory::identify(Storage::disk('public')->path($spreadsheetPath)));
+    }
+
+    public function test_user_cannot_export_data_for_an_inaccessible_course(): void
+    {
+        $user = User::factory()->create();
+        $course = $this->createCourse();
+        $spreadsheetPath = 'spreadsheets/data-summary-course-'.$course->course_id.'.xlsx';
+
+        $this->actingAs($user)
+            ->get(route('courses.dataSpreadsheet', $course->course_id))
+            ->assertRedirect('/courses');
+
+        Storage::disk('public')->assertMissing($spreadsheetPath);
+    }
+
+    private function createAccessibleCourse(User $user): Course
+    {
+        $course = $this->createCourse();
+        $course->users()->attach($user->id, ['permission' => 1]);
+
+        return $course;
+    }
+
+    private function createCourse(): Course
+    {
+        return Course::factory()->create([
+            'standard_category_id' => DB::table('standard_categories')->value('standard_category_id'),
+            'scale_category_id' => DB::table('standards_scale_categories')->value('scale_category_id'),
+        ]);
+    }
+}

--- a/laravel/tests/Feature/SearchTest.php
+++ b/laravel/tests/Feature/SearchTest.php
@@ -14,6 +14,7 @@ use App\Models\CourseTopic;
 use App\Models\LearningOutcome;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use PDF;
 
 class SearchTest extends TestCase
 {
@@ -125,6 +126,74 @@ class SearchTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSessionHasNoErrors();
+    }
+
+    public function test_course_search_results_can_be_exported_as_pdf(): void
+    {
+        $this->createCourseScaleCategory();
+        $course = Course::factory()->create([
+            'course_code' => 'FRST',
+            'course_num' => 321,
+            'course_title' => 'Zephyrexport Forestry',
+        ]);
+
+        PDF::shouldReceive('loadView')
+            ->once()
+            ->with('search.exports.course-results', \Mockery::on(fn ($data) =>
+                $data['searchTerm'] === 'zephyrexport'
+                && $data['results']->contains('course_id', $course->course_id)
+            ))
+            ->andReturnSelf();
+        PDF::shouldReceive('download')
+            ->once()
+            ->with('course-search-results-'.now()->format('Y-m-d').'.pdf')
+            ->andReturn(response('%PDF', 200, ['Content-Type' => 'application/pdf']));
+
+        $response = $this->get(route('search.export.pdf', [
+            'query' => 'zephyrexport',
+            'view' => 'courses',
+        ]));
+
+        $response->assertOk()->assertHeader('Content-Type', 'application/pdf');
+    }
+
+    public function test_program_search_results_can_be_exported_as_pdf(): void
+    {
+        $this->createCourseScaleCategory();
+        $course = Course::factory()->create([
+            'course_title' => 'Auralithpdfexport Course',
+        ]);
+        $programId = DB::table('programs')->insertGetId([
+            'program' => 'Auralithpdfexport Program',
+            'level' => 'Bachelors',
+            'status' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'program_id');
+        DB::table('course_programs')->insert([
+            'course_id' => $course->course_id,
+            'program_id' => $programId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        PDF::shouldReceive('loadView')
+            ->once()
+            ->with('search.exports.program-results', \Mockery::on(fn ($data) =>
+                $data['programResults']->contains('program_id', $programId)
+            ))
+            ->andReturnSelf();
+        PDF::shouldReceive('download')
+            ->once()
+            ->with('program-search-results-'.now()->format('Y-m-d').'.pdf')
+            ->andReturn(response('%PDF', 200, ['Content-Type' => 'application/pdf']));
+
+        $response = $this->get(route('search.export.pdf', [
+            'query' => 'auralithpdfexport',
+            'view' => 'programs',
+        ]));
+
+        $response->assertOk()->assertHeader('Content-Type', 'application/pdf');
     }
 
     public function test_search_finds_course_by_compact_course_code(){

--- a/laravel/tests/Feature/SearchTest.php
+++ b/laravel/tests/Feature/SearchTest.php
@@ -134,23 +134,23 @@ class SearchTest extends TestCase
         $course = Course::factory()->create([
             'course_code' => 'FRST',
             'course_num' => 321,
-            'course_title' => 'Zephyrexport Forestry',
+            'course_title' => 'Zephyr Export Forestry',
         ]);
 
         PDF::shouldReceive('loadView')
             ->once()
             ->with('search.exports.course-results', \Mockery::on(fn ($data) =>
-                $data['searchTerm'] === 'zephyrexport'
+                $data['searchTerm'] === 'zephyr export'
                 && $data['results']->contains('course_id', $course->course_id)
             ))
             ->andReturnSelf();
         PDF::shouldReceive('download')
             ->once()
-            ->with('course-search-results-'.now()->format('Y-m-d').'.pdf')
+            ->with('zephyr-export-course-search-results-'.now()->format('Y-m-d').'.pdf')
             ->andReturn(response('%PDF', 200, ['Content-Type' => 'application/pdf']));
 
         $response = $this->get(route('search.export.pdf', [
-            'query' => 'zephyrexport',
+            'query' => 'zephyr export',
             'view' => 'courses',
         ]));
 
@@ -185,7 +185,7 @@ class SearchTest extends TestCase
             ->andReturnSelf();
         PDF::shouldReceive('download')
             ->once()
-            ->with('program-search-results-'.now()->format('Y-m-d').'.pdf')
+            ->with('auralithpdfexport-program-search-results-'.now()->format('Y-m-d').'.pdf')
             ->andReturn(response('%PDF', 200, ['Content-Type' => 'application/pdf']));
 
         $response = $this->get(route('search.export.pdf', [


### PR DESCRIPTION
This PR adds PDF export functionality to Course Search so users can download and share the results of useful searches.

- Added a Download PDF button to Course Search results.
- Added PDF exports for both Course View and Program View.
- Included the search query, selected filters, matching courses/programs, highlighted snippets, and material-content source details in the exports.
- Exported all matching results rather than only the current pagination page.
- Added descriptive filenames containing the search query, selected view, and date.
- Added focused tests for search exports and existing course export behaviour.
- Updated `docs/search.md` with PDF export details.

Notes:

- Spreadsheet export was considered but removed from the final implementation because PDF better represents the ranked results, grouped programs, and matching snippets shown by Course Search.
- Very broad searches containing thousands of results may need to be narrowed before export because PDF generation has a higher memory cost.

Tests:

- `php artisan test tests/Feature/CourseExportTest.php tests/Feature/SearchTest.php`
- 65 tests passed with 271 assertions.

Please refer to `docs/search.md` for more information about Course Search exports.